### PR TITLE
docker: configuration improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+*.pyc
+*.so
+*.o
+__pycache__/
+.tox
+.coverage
+.cache
+*.egg-info/
+*.egg/
+build/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,42 @@
 # under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-# docker build .
-FROM python:3.4
-RUN pip install pep257 "coverage<4.0a1"
-RUN pip install pytest pytest-pep8 pytest-cov pytest-cache
-RUN pip install mock httpretty requests
-RUN pip install sphinx_rtd_theme
+# Use Python-2.7 image:
+FROM python:2.7
+
+# Install some prerequisites ahead of `setup.py` in order to profit
+# from the docker build cache:
+RUN pip install "coverage<4.0a1" \
+                docutils \
+                httpretty \
+                jinja2 \
+                markupsafe \
+                mock \
+                pep257 \
+                pytest \
+                pytest-cache \
+                pytest-cov \
+                pytest-pep8 \
+                requests \
+                sphinx \
+                sphinx-rtd-theme
+
+# Add sources to `/code` and work there:
 ADD . /code
 WORKDIR /code
-RUN pip install -e .
+
+# Install DataCite:
+RUN pip install -e .[docs]
+
+# Run container as user `datacite` with UID `1000`, which should match
+# current host user in most situations:
+RUN adduser --uid 1000 --disabled-password --gecos '' datacite && \
+    chown -R datacite:datacite /code
+USER datacite
+
+# Run PEP-257 check and build documentation:
 RUN pep257 datacite
-RUN sphinx-build -qnNW docs docs/_build/html
-RUN python setup.py test
+RUN python setup.py build_sphinx
+
+# Run test suite instead of starting the application:
+CMD ["python", "setup.py", "test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# This file is part of DataCite.
+#
+# Copyright (C) 2015 CERN.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+web:
+  build: .
+  command: python setup.py test
+  volumes:
+   - .:/code


### PR DESCRIPTION
* Improves Docker configuration to reduce the number of image layers, to
  profit from wider build cache, and to run the scripts under the host
  user identity.

* Adds `docker-compose` configuration.  `docker-compose build` rebuilds
  the image, `docker-compose up` runs the test suite.

* Adds basic `.dockerignore`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>