### PR TITLE
Fix label for titleType

### DIFF
--- a/datacite/schemas/datacite-v4.0.json
+++ b/datacite/schemas/datacite-v4.0.json
@@ -103,7 +103,7 @@
             "type": "string",
             "minLength": 1
           },
-          "type": {
+          "titleType": {
             "enum": [
               "AlternativeTitle",
               "Subtitle",

--- a/tests/data/datacite-v4.0-full-example.json
+++ b/tests/data/datacite-v4.0-full-example.json
@@ -30,7 +30,7 @@
     },
     {
       "title": "Demonstration of DataCite Properties.",
-      "type": "Subtitle",
+      "titleType": "Subtitle",
       "lang": "en-us"
     }
   ],


### PR DESCRIPTION
The v4.0 schema label for the type of title is "titleType" not "type"