### PR TITLE
Remove usages of mutable default arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # This file is part of DataCite.
 #
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2018 Center for Open Science.
 #
 # DataCite is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -48,6 +49,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # This file is part of DataCite.
 #
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2018 Center for Open Science.
 #
 # DataCite is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -20,6 +21,7 @@ cache:
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 env:
   - REQUIREMENTS=lowest

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
 DataCite is free software; you can redistribute it and/or modify
 it under the terms of the Revised BSD License quoted below.
 
-Copyright (C) 2015-2016 CERN.
+Copyright (C) 2015-2018 CERN.
+Copyright (C) 2018 Center for Open Science.
 
 All rights reserved.
 

--- a/LICENSE
+++ b/LICENSE
@@ -33,7 +33,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-In applying this license, CERN does not waive the privileges and
-immunities granted to it by virtue of its status as an
-Intergovernmental Organization or submit itself to any jurisdiction.

--- a/datacite/request.py
+++ b/datacite/request.py
@@ -2,7 +2,8 @@
 #
 # This file is part of DataCite.
 #
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2018 Center for Open Science.
 #
 # DataCite is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -35,15 +36,15 @@ class DataCiteRequest(object):
     """
 
     def __init__(self, base_url=None, username=None, password=None,
-                 default_params={}, timeout=None):
+                 default_params=None, timeout=None):
         """Initialize request object."""
         self.base_url = base_url
         self.username = username
         self.password = password
-        self.default_params = default_params
+        self.default_params = default_params or {}
         self.timeout = timeout
 
-    def request(self, url, method='GET', body=None, params={}, headers={}):
+    def request(self, url, method='GET', body=None, params=None, headers=None):
         """Make a request.
 
         If the request was successful (i.e no exceptions), you can find the
@@ -55,6 +56,9 @@ class DataCiteRequest(object):
         :param params: Request parameters
         :param headers: Request headers
         """
+        params = params or {}
+        headers = headers or {}
+
         self.data = None
         self.code = None
 
@@ -90,16 +94,22 @@ class DataCiteRequest(object):
         except ssl.SSLError as e:
             raise HttpError(e)
 
-    def get(self, url, params={}, headers={}):
+    def get(self, url, params=None, headers=None):
         """Make a GET request."""
+        params = params or {}
+        headers = headers or {}
         return self.request(url, params=params, headers=headers)
 
-    def post(self, url, body=None, params={}, headers={}):
+    def post(self, url, body=None, params=None, headers=None):
         """Make a POST request."""
+        params = params or {}
+        headers = headers or {}
         return self.request(url, method="POST", body=body, params=params,
                             headers=headers)
 
-    def delete(self, url, params={}, headers={}):
+    def delete(self, url, params=None, headers=None):
         """Make a DELETE request."""
+        params = params or {}
+        headers = headers or {}
         return self.request(url, method="DELETE", params=params,
                             headers=headers)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,4 +79,10 @@ License
 
 .. include:: ../LICENSE
 
+.. note::
+
+    In applying this license, CERN does not waive the privileges and immunities
+    granted to it by virtue of its status as an Intergovernmental Organization
+    or submit itself to any jurisdiction.
+
 .. include:: ../AUTHORS.rst

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Default arguments are evaluated once, when methods are defined.
Multiple calls to the same method could therefore use the same
dictionary, which could lead to hard-to-trace bugs.

http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments