### PR TITLE
Fix download and license badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@
 .. image:: https://img.shields.io/pypi/v/datacite.svg?maxAge=2592000
    :target: https://pypi.python.org/pypi/datacite/
 
-.. image:: https://img.shields.io/pypi/dm/datacite.svg?maxAge=2592000
+.. image:: https://pepy.tech/badge/datacite?maxAge=2592000
    :target: https://pypi.python.org/pypi/datacite/
 
-.. image:: https://img.shields.io/github/license/inveniosoftware/datacite.svg
+.. image:: https://img.shields.io/pypi/l/datacite.svg
    :target: https://github.com/inveniosoftware/datacite/blob/master/LICENSE
 
 .. image:: https://img.shields.io/github/tag/inveniosoftware/datacite.svg


### PR DESCRIPTION
The shields.io download count badges are no longer functional,
but pepy.tech badges work.

The license badge now reads from PyPI metadata rather than
using GitHub's guessing algorithm.

<img width="196" alt="datacite 2018-07-02 08-08-48" src="https://user-images.githubusercontent.com/2379650/42163182-8c598d14-7dcf-11e8-9779-54ea66c94090.png">
