### PR TITLE
[WIP] Update metadata_post to match new DataCite API

### DIFF
--- a/datacite/client.py
+++ b/datacite/client.py
@@ -119,18 +119,21 @@ class DataCiteMDSClient(object):
             raise DataCiteError.factory(r.code, r.data)
 
     def metadata_post(self, metadata):
-        """Set new metadata for an existing DOI.
+        """Set new metadata for a new or existing DOI.
 
         Metadata should follow the DataCite Metadata Schema:
         http://schema.datacite.org/
 
+        If you want DataCite to create the full identifier for you, 
+        put just the prefix in the identifier section of the XML.
+
         :param metadata: XML format of the metadata.
-        :return: "CREATED" or "HANDLE_ALREADY_EXISTS"
+        :return: "OK (PREFIX/SUFFIX)" or "HANDLE_ALREADY_EXISTS"
         """
         headers = {'Content-Type': 'application/xml;charset=UTF-8', }
 
         r = self._request_factory()
-        r.post("metadata", body=metadata, headers=headers)
+        r.put("metadata/" + self.prefix, body=metadata, headers=headers)
 
         if r.code == 201:
             return r.data

--- a/datacite/request.py
+++ b/datacite/request.py
@@ -80,6 +80,8 @@ class DataCiteRequest(object):
 
         if method == 'POST':
             kwargs['data'] = body
+        if method == 'PUT':
+            kwargs['data'] = body
         if self.timeout is not None:
             kwargs['timeout'] = self.timeout
 
@@ -107,9 +109,23 @@ class DataCiteRequest(object):
         return self.request(url, method="POST", body=body, params=params,
                             headers=headers)
 
+    def put(self, url, body=None, params=None, headers=None):
+        """Make a PUT request."""
+        params = params or {}
+        headers = headers or {}
+        return self.request(url, method="PUT", body=body, params=params,
+                            headers=headers)
+
     def delete(self, url, params=None, headers=None):
         """Make a DELETE request."""
         params = params or {}
         headers = headers or {}
         return self.request(url, method="DELETE", params=params,
+                            headers=headers)
+
+    def put(self, url, body=None, params=None, headers=None):
+        """Make a PUT request."""
+        params = params or {}
+        headers = headers or {}
+        return self.request(url, method="PUT", body=body, params=params,
                             headers=headers)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -25,8 +25,8 @@ def test_example():
 
     # metadata post
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
         body="CREATED",
         status=201,
     )

--- a/tests/test_metadata_post.py
+++ b/tests/test_metadata_post.py
@@ -24,14 +24,14 @@ from datacite.errors import DataCiteBadRequestError, DataCiteForbiddenError, \
 def test_metadata_post_201():
     """Test."""
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
-        body="OK",
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
+        body="CREATED",
         status=201,
     )
 
     d = get_client(test_mode=True)
-    assert "OK" == d.metadata_post("<resource></resource>")
+    assert "CREATED" == d.metadata_post("<resource></resource>")
     assert responses.calls[0].request.headers['content-type'] == \
         "application/xml;charset=UTF-8"
     assert responses.calls[0].response.url.split('?')[-1] == 'testMode=1'
@@ -41,8 +41,8 @@ def test_metadata_post_201():
 def test_metadata_post_400():
     """Test."""
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
         body="Bad Request",
         status=400,
     )
@@ -56,8 +56,8 @@ def test_metadata_post_400():
 def test_metadata_post_401():
     """Test."""
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
         body="Unauthorized",
         status=401,
     )
@@ -71,8 +71,8 @@ def test_metadata_post_401():
 def test_metadata_post_403():
     """Test."""
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
         body="Forbidden",
         status=403,
     )
@@ -86,8 +86,8 @@ def test_metadata_post_403():
 def test_metadata_post_500():
     """Test."""
     responses.add(
-        responses.POST,
-        "{0}metadata".format(APIURL),
+        responses.PUT,
+        "{0}metadata/10.5072".format(APIURL),
         body="Internal Server Error",
         status=500,
     )


### PR DESCRIPTION
DataCite has switched their api call for metadata registration POST to PUT (https://support.datacite.org/docs/mds-api-guide#section-register-metadata).  The current (POST) version is still supported, but if we switch we gain the ability to have DataCite generate DOIs with the recommended formatting (Issue #29 - which is hard to do from python).  There should be no change to any existing behavior.