### PR TITLE
4.2 schema updates from DataCite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,19 @@
 Changes
 =======
+Version v1.1.0 (TBD):
+
+- Adds full support for DataCite Metadata Schema v4.2 XML generation.
+- Uses Official DataCite JSON Schema, which has the following notable changes
+  from the previous schema:
+  
+  - Uses "identifiers" which is a combination of the XML "identifier" and
+    "alternativeIdentifiers" elements
+  - "creatorName" is now "name"
+  - "contributorName" is now "name"
+  - "affiliations" is now "affiliation" (is still an array)
+  - There is no longer a funder identifier object (the identifier and type are just
+    elements)
+
 Version v1.0.1 (released 2018-03-08):
 
 - Fixes schema location url for DataCite v4.1

--- a/datacite/schema42.py
+++ b/datacite/schema42.py
@@ -66,8 +66,6 @@ def identifiers(path, values):
     alt = ''
     doi = ''
     for value in values:
-        print(value['identifierType'])
-        print(value['identifierType'] == 'DOI')
         if value['identifierType'] == 'DOI':
             if doi != '':
                 # Don't know what to do with two DOIs

--- a/datacite/schemas/datacite-v4.2.json
+++ b/datacite/schemas/datacite-v4.2.json
@@ -1,643 +1,480 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
 
-  "definitions": {
-    "nameType": {
-      "type": "string",
-      "enum": [
-        "Organizational",
-        "Personal"
-      ]
-    },
-    "nameIdentifiers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "nameIdentifier": {
-            "type": "string"
-          },
-          "nameIdentifierScheme": {
-            "type": "string"
-          },
-          "schemeURI": {
+    "definitions": {
+        "nameType": {
             "type": "string",
-            "format": "uri"
-          }
+            "enum": [
+                "Organizational",
+                "Personal"
+            ]
         },
-        "required": ["nameIdentifier", "nameIdentifierScheme"]
-      },
-      "uniqueItems": true
-    },
-    "affiliations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "affiliation": {
-            "type": "string"
-          }
-        },
-        "required": ["affiliation"]
-      },
-      "uniqueItems": true
-    },
-    "titleType": {
-      "type": "string",
-      "enum": [
-        "AlternativeTitle",
-        "Subtitle",
-        "TranslatedTitle",
-        "Other"
-      ]
-    },
-    "contributorType": {
-      "type": "string",
-      "enum": [
-        "ContactPerson",
-        "DataCollector",
-        "DataCurator",
-        "DataManager",
-        "Distributor",
-        "Editor",
-        "HostingInstitution",
-        "Producer",
-        "ProjectLeader",
-        "ProjectManager",
-        "ProjectMember",
-        "RegistrationAgency",
-        "RegistrationAuthority",
-        "RelatedPerson",
-        "Researcher",
-        "ResearchGroup",
-        "RightsHolder",
-        "Sponsor",
-        "Supervisor",
-        "WorkPackageLeader",
-        "Other"
-      ]
-    },
-    "date": {
-      "type": "string",
-      "anyOf": [{
-          "format": "year"
-        },
-        {
-          "format": "yearmonth"
-        },
-        {
-          "format": "date"
-        },
-        {
-          "format": "datetime"
-        },
-        {
-          "format": "year-range"
-        },
-        {
-          "format": "yearmonth-range"
-        },
-        {
-          "format": "date-range"
-        },
-        {
-          "format": "datetime-range"
-        }
-      ]
-    },
-    "dateType": {
-      "type": "string",
-      "enum": [
-        "Accepted",
-        "Available",
-        "Copyrighted",
-        "Collected",
-        "Created",
-        "Issued",
-        "Submitted",
-        "Updated",
-        "Valid",
-        "Withdrawn",
-        "Other"
-      ]
-    },
-    "resourceTypeGeneral": {
-      "type": "string",
-      "enum": [
-        "Audiovisual",
-        "Collection",
-        "DataPaper",
-        "Dataset",
-        "Event",
-        "Image",
-        "InteractiveResource",
-        "Model",
-        "PhysicalObject",
-        "Service",
-        "Software",
-        "Sound",
-        "Text",
-        "Workflow",
-        "Other"
-      ]
-    },
-    "relatedIdentifierType": {
-      "type": "string",
-      "enum": [
-        "ARK",
-        "arXiv",
-        "bibcode",
-        "DOI",
-        "EAN13",
-        "EISSN",
-        "Handle",
-        "IGSN",
-        "ISBN",
-        "ISSN",
-        "ISTC",
-        "LISSN",
-        "LSID",
-        "PMID",
-        "PURL",
-        "UPC",
-        "URL",
-        "URN",
-        "w3id"
-      ]
-    },
-    "relationType": {
-      "type": "string",
-      "enum": [
-        "IsCitedBy",
-        "Cites",
-        "IsSupplementTo",
-        "IsSupplementedBy",
-        "IsContinuedBy",
-        "Continues",
-        "IsDescribedBy",
-        "Describes",
-        "HasMetadata",
-        "IsMetadataFor",
-        "HasVersion",
-        "IsVersionOf",
-        "IsNewVersionOf",
-        "IsPreviousVersionOf",
-        "IsPartOf",
-        "HasPart",
-        "IsReferencedBy",
-        "References",
-        "IsDocumentedBy",
-        "Documents",
-        "IsCompiledBy",
-        "Compiles",
-        "IsVariantFormOf",
-        "IsOriginalFormOf",
-        "IsIdenticalTo",
-        "IsReviewedBy",
-        "Reviews",
-        "IsDerivedFrom",
-        "IsSourceOf",
-        "IsRequiredBy",
-        "Requires",
-        "IsObsoletedBy",
-        "Obsoletes"
-      ]
-    },
-    "descriptionType": {
-      "type": "string",
-      "enum": [
-        "Abstract",
-        "Methods",
-        "SeriesInformation",
-        "TableOfContents",
-        "TechnicalInfo",
-        "Other"
-      ]
-    },
-    "geoLocationPoint": {
-      "type": "object",
-      "properties": {
-        "pointLongitude": {
-          "type": "string",
-          "format": "longitude"
-        },
-        "pointLatitude": {
-          "type": "string",
-          "format": "latitude"
-        }
-      },
-      "required": ["pointLongitude", "pointLatitude"]
-    },
-    "funderIdentifierType": {
-      "type": "string",
-      "enum": [
-        "ISNI",
-        "GRID",
-        "Crossref Funder ID",
-        "Other"
-      ]
-    }
-  },
-
-  "type": "object",
-
-  "properties": {
-    "types": {
-      "type": "object",
-      "properties": {
-        "resourceType": {
-          "type": "string"
-        },
-        "resourceTypeGeneral": {
-          "$ref": "#/definitions/resourceTypeGeneral"
-        }
-      },
-      "required": ["resourceType", "resourceTypeGeneral"]
-    },
-    "identifier": {
-      "type": "object",
-      "properties": {
-        "identifier": {
-          "type": "string",
-          "pattern": "^10\\.\\d+(\\.\\d+)*/.+$"
-        },
-        "identifierType": {
-          "type": "string",
-          "enum": ["DOI"]
-        }
-      },
-      "required": ["identifier", "identifierType"]
-    },
-    "creators": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "lang": {
-            "type": "string"
-          },
-          "nameType": {
-            "$ref": "#/definitions/nameType"
-          },
-          "givenName": {
-            "type": "string"
-          },
-          "familyName": {
-            "type": "string"
-          },
-          "nameIdentifiers": {
-            "$ref": "#/definitions/nameIdentifiers"
-          },
-          "affiliations": {
-            "$ref": "#/definitions/affiliations"
-          }
-        },
-        "required": ["name"]
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "titles": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "titleType": {
-            "$ref": "#/definitions/titleType"
-          },
-          "lang": {
-            "type": "string"
-          }
-        },
-        "required": ["title"]
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "publisher": {
-      "type": "string"
-    },
-    "publicationYear": {
-      "type": "string",
-      "format": "year"
-    },
-    "subjects": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "subject": {
-            "type": "string"
-          },
-          "subjectScheme": {
-            "type": "string"
-          },
-          "schemeURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "valueURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "lang": {
-            "type": "string"
-          }
-        },
-        "required": ["subject"]
-      },
-      "uniqueItems": true
-    },
-    "contributors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "contributorType": {
-            "$ref": "#/definitions/contributorType"
-          },
-          "name": {
-            "type": "string"
-          },
-          "lang": {
-            "type": "string"
-          },
-          "nameType": {
-            "$ref": "#/definitions/nameType"
-          },
-          "givenName": {
-            "type": "string"
-          },
-          "familyName": {
-            "type": "string"
-          },
-          "nameIdentifiers": {
-            "$ref": "#/definitions/nameIdentifiers"
-          },
-          "affiliations": {
-            "$ref": "#/definitions/affiliations"
-          }
-        },
-        "required": ["contributorType", "name"]
-      },
-      "uniqueItems": true
-    },
-    "dates": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "date": {
-            "$ref": "#/definitions/date"
-          },
-          "dateType": {
-            "$ref": "#/definitions/dateType"
-          },
-          "dateInformation": {
-            "type": "string"
-          }
-        },
-        "required": ["date", "dateType"]
-      },
-      "uniqueItems": true
-    },
-    "language": {
-      "type": "string",
-      "$comment": "Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes."
-    },
-    "alternateIdentifiers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "alternateIdentifier": {
-            "type": "string"
-          },
-          "alternateIdentifierType": {
-            "type": "string"
-          }
-        },
-        "required": ["alternateIdentifier", "alternateIdentifierType"]
-      },
-      "uniqueItems": true
-    },
-    "relatedIdentifiers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "relatedIdentifier": {
-            "type": "string"
-          },
-          "relatedIdentifierType": {
-            "$ref": "#/definitions/relatedIdentifierType"
-          },
-          "relationType": {
-            "$ref": "#/definitions/relationType"
-          },
-          "relatedMetadataScheme": {
-            "type": "string"
-          },
-          "schemeURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "schemeType": {
-            "type": "string"
-          },
-          "resourceTypeGeneral": {
-            "$ref": "#/definitions/resourceTypeGeneral"
-          }
-        },
-        "required": ["relatedIdentifier", "relatedIdentifierType", "relationType"],
-        "if": {
-          "properties": {
-            "relationType": {
-              "enum": ["HasMetadata", "IsMetadataFor"]
-            }
-          }
-        },
-        "else": {
-          "$comment": "these properties may only be used with relation types HasMetadata/IsMetadataFor",
-          "properties": {
-            "relatedMetadataScheme": false,
-            "schemeURI": false,
-            "schemeType": false
-          }
-        }
-      },
-      "uniqueItems": true
-    },
-    "sizes": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-    "formats": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-    "version": {
-      "type": "string"
-    },
-    "rightsList": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "rights": {
-            "type": "string"
-          },
-          "rightsURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "rightsIdentifier": {
-            "type": "string"
-          },
-          "rightsIdentifierScheme": {
-            "type": "string"
-          },
-          "schemeURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "lang": {
-            "type": "string"
-          }
-        }
-      },
-      "uniqueItems": true
-    },
-    "descriptions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "descriptionType": {
-            "$ref": "#/definitions/descriptionType"
-          },
-          "lang": {
-            "type": "string"
-          }
-        },
-        "required": ["description", "descriptionType"]
-      },
-      "uniqueItems": true
-    },
-    "geoLocations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "geoLocationPlace": {
-            "type": "string"
-          },
-          "geoLocationPoint": {
-            "$ref": "#/definitions/geoLocationPoint"
-          },
-          "geoLocationBox": {
-            "type": "object",
-            "properties": {
-              "westBoundLongitude": {
-                "type": "string",
-                "format": "longitude"
-              },
-              "eastBoundLongitude": {
-                "type": "string",
-                "format": "longitude"
-              },
-              "southBoundLatitude": {
-                "type": "string",
-                "format": "latitude"
-              },
-              "northBoundLatitude": {
-                "type": "string",
-                "format": "latitude"
-              }
-            },
-            "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
-          },
-          "geoLocationPolygons": {
+        "nameIdentifiers": {
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "polygonPoints": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/geoLocationPoint"
-                  },
-                  "minItems": 4
+                "type": "object",
+                "properties": {
+                    "nameIdentifier": {"type": "string"},
+                    "nameIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"}
                 },
-                "inPolygonPoint": {
-                  "$ref": "#/definitions/geoLocationPoint"
-                }
-              },
-              "required": ["polygonPoints"]
+                "required": ["nameIdentifier", "nameIdentifierScheme"]
             },
             "uniqueItems": true
-          }
-        }
-      },
-      "uniqueItems": true
-    },
-    "fundingReferences": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "funderName": {
-            "type": "string"
-          },
-          "funderIdentifier": {
-            "type": "string"
-          },
-          "funderIdentifierType": {
-            "$ref": "#/definitions/funderIdentifierType"
-          },
-          "awardNumber": {
-            "type": "string"
-          },
-          "awardURI": {
-            "type": "string",
-            "format": "uri"
-          },
-          "awardTitle": {
-            "type": "string"
-          }
         },
-        "required": ["funderName"]
-      },
-      "uniqueItems": true
+        "affiliations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "affiliation": {"type": "string"}
+                },
+                "required": ["affiliation"]
+            },
+            "uniqueItems": true
+        },
+        "titleType": {
+            "type": "string",
+            "enum": [
+                "AlternativeTitle",
+                "Subtitle",
+                "TranslatedTitle",
+                "Other"
+            ]
+        },
+        "contributorType": {
+            "type": "string",
+            "enum": [
+                "ContactPerson",
+                "DataCollector",
+                "DataCurator",
+                "DataManager",
+                "Distributor",
+                "Editor",
+                "HostingInstitution",
+                "Producer",
+                "ProjectLeader",
+                "ProjectManager",
+                "ProjectMember",
+                "RegistrationAgency",
+                "RegistrationAuthority",
+                "RelatedPerson",
+                "Researcher",
+                "ResearchGroup",
+                "RightsHolder",
+                "Sponsor",
+                "Supervisor",
+                "WorkPackageLeader",
+                "Other"
+            ]
+        },
+        "date": {
+            "type": "string",
+            "anyOf": [
+                {"format": "year"},
+                {"format": "yearmonth"},
+                {"format": "date"},
+                {"format": "datetime"},
+                {"format": "year-range"},
+                {"format": "yearmonth-range"},
+                {"format": "date-range"},
+                {"format": "datetime-range"}
+            ]
+        },
+        "dateType": {
+            "type": "string",
+            "enum": [
+                "Accepted",
+                "Available",
+                "Copyrighted",
+                "Collected",
+                "Created",
+                "Issued",
+                "Submitted",
+                "Updated",
+                "Valid",
+                "Withdrawn",
+                "Other"
+            ]
+        },
+        "resourceTypeGeneral": {
+            "type": "string",
+            "enum": [
+                "Audiovisual",
+                "Collection",
+                "DataPaper",
+                "Dataset",
+                "Event",
+                "Image",
+                "InteractiveResource",
+                "Model",
+                "PhysicalObject",
+                "Service",
+                "Software",
+                "Sound",
+                "Text",
+                "Workflow",
+                "Other"
+            ]
+        },
+        "relatedIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ARK",
+                "arXiv",
+                "bibcode",
+                "DOI",
+                "EAN13",
+                "EISSN",
+                "Handle",
+                "IGSN",
+                "ISBN",
+                "ISSN",
+                "ISTC",
+                "LISSN",
+                "LSID",
+                "PMID",
+                "PURL",
+                "UPC",
+                "URL",
+                "URN",
+                "w3id"
+            ]
+        },
+        "relationType": {
+            "type": "string",
+            "enum": [
+                "IsCitedBy",
+                "Cites",
+                "IsSupplementTo",
+                "IsSupplementedBy",
+                "IsContinuedBy",
+                "Continues",
+                "IsDescribedBy",
+                "Describes",
+                "HasMetadata",
+                "IsMetadataFor",
+                "HasVersion",
+                "IsVersionOf",
+                "IsNewVersionOf",
+                "IsPreviousVersionOf",
+                "IsPartOf",
+                "HasPart",
+                "IsReferencedBy",
+                "References",
+                "IsDocumentedBy",
+                "Documents",
+                "IsCompiledBy",
+                "Compiles",
+                "IsVariantFormOf",
+                "IsOriginalFormOf",
+                "IsIdenticalTo",
+                "IsReviewedBy",
+                "Reviews",
+                "IsDerivedFrom",
+                "IsSourceOf",
+                "IsRequiredBy",
+                "Requires",
+                "IsObsoletedBy",
+                "Obsoletes"
+            ]
+        },
+        "descriptionType": {
+            "type": "string",
+            "enum": [
+                "Abstract",
+                "Methods",
+                "SeriesInformation",
+                "TableOfContents",
+                "TechnicalInfo",
+                "Other"
+            ]
+        },
+        "geoLocationPoint": {
+            "type": "object",
+            "properties": {
+                "pointLongitude": {"type": "string", "format": "longitude"},
+                "pointLatitude": {"type": "string", "format": "latitude"}
+            },
+            "required": ["pointLongitude", "pointLatitude"]
+        },
+        "funderIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ISNI",
+                "GRID",
+                "Crossref Funder ID",
+                "Other"
+            ]
+        }
     },
-    "schemaVersion": {
-      "type": "string",
-      "const": "http://datacite.org/schema/kernel-4"
-    }
-  },
 
-  "required": [
-    "identifier",
-    "creators",
-    "titles",
-    "publisher",
-    "publicationYear",
-    "types",
-    "schemaVersion"
-  ]
+    "type": "object",
+
+    "properties": {
+        "types": {
+            "type": "object",
+            "properties": {
+                "resourceType": {"type": "string"},
+                "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+            },
+            "required": ["resourceType", "resourceTypeGeneral"]
+        },
+        "identifiers": {
+            "type": "array",
+            "items":{
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string"},
+                    "identifierType": {"type": "string"}
+                },
+                "required": ["identifier", "identifierType"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "creators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["name"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "titles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "titleType": {"$ref": "#/definitions/titleType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["title"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "publisher": {
+            "type": "string"
+        },
+        "publicationYear": {
+            "type": "string",
+            "format": "year"
+        },
+        "subjects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "subjectScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "valueURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["subject"]
+            },
+            "uniqueItems": true
+        },
+        "contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "contributorType": {"$ref": "#/definitions/contributorType"},
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["contributorType", "name"]
+            },
+            "uniqueItems": true
+        },
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "date": {"$ref": "#/definitions/date"},
+                    "dateType": {"$ref": "#/definitions/dateType"},
+                    "dateInformation": {"type": "string"}
+                },
+                "required": ["date", "dateType"]
+            },
+            "uniqueItems": true
+        },
+        "language": {
+            "type": "string",
+            "$comment": "Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes."
+        },
+        "alternateIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "alternateIdentifier": {"type": "string"},
+                    "alternateIdentifierType": {"type": "string"}
+                },
+                "required": ["alternateIdentifier", "alternateIdentifierType"]
+            },
+            "uniqueItems": true
+        },
+        "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "relatedIdentifier": {"type": "string"},
+                    "relatedIdentifierType": {"$ref": "#/definitions/relatedIdentifierType"},
+                    "relationType": {"$ref": "#/definitions/relationType"},
+                    "relatedMetadataScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "schemeType": {"type": "string"},
+                    "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+                },
+                "required": ["relatedIdentifier", "relatedIdentifierType", "relationType"],
+                "if": {
+                    "properties": {
+                        "relationType": {"enum": ["HasMetadata", "IsMetadataFor"]}
+                    }
+                },
+                "else": {
+                    "$comment": "these properties may only be used with relation types HasMetadata/IsMetadataFor",
+                    "properties": {
+                        "relatedMetadataScheme": false,
+                        "schemeURI": false,
+                        "schemeType": false
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "sizes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "version": {
+            "type": "string"
+        },
+        "rightsList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rights": {"type": "string"},
+                    "rightsURI": {"type": "string", "format": "uri"},
+                    "rightsIdentifier": {"type": "string"},
+                    "rightsIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                }
+            },
+            "uniqueItems": true
+        },
+        "descriptions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "description": {"type": "string"},
+                    "descriptionType": {"$ref": "#/definitions/descriptionType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["description", "descriptionType"]
+            },
+            "uniqueItems": true
+        },
+        "geoLocations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "geoLocationPlace": {"type": "string"},
+                    "geoLocationPoint": {"$ref": "#/definitions/geoLocationPoint"},
+                    "geoLocationBox": {
+                        "type": "object",
+                        "properties": {
+                            "westBoundLongitude": {"type": "string", "format": "longitude"},
+                            "eastBoundLongitude": {"type": "string", "format": "longitude"},
+                            "southBoundLatitude": {"type": "string", "format": "latitude"},
+                            "northBoundLatitude": {"type": "string", "format": "latitude"}
+                        },
+                        "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
+                    },
+                    "geoLocationPolygons": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "polygonPoints": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/definitions/geoLocationPoint"},
+                                    "minItems": 4
+                                },
+                                "inPolygonPoint": {"$ref": "#/definitions/geoLocationPoint"}
+                            },
+                            "required": ["polygonPoints"]
+                        },
+                        "uniqueItems": true
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "fundingReferences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "funderName": {"type": "string"},
+                    "funderIdentifier": {"type": "string"},
+                    "funderIdentifierType": {"$ref": "#/definitions/funderIdentifierType"},
+                    "awardNumber": {"type": "string"},
+                    "awardURI": {"type": "string", "format": "uri"},
+                    "awardTitle": {"type": "string"}
+                },
+                "required": ["funderName"]
+            },
+            "uniqueItems": true
+        },
+        "schemaVersion": {
+            "type": "string",
+            "const": "http://datacite.org/schema/kernel-4"
+        }
+    },
+
+    "required": [
+        "identifiers",
+        "creators",
+        "titles",
+        "publisher",
+        "publicationYear",
+        "types",
+        "schemaVersion"
+    ]
 }

--- a/datacite/xmlutils.py
+++ b/datacite/xmlutils.py
@@ -29,7 +29,12 @@ def dump_etree_helper(data, rules, nsmap, attrib):
 
         element = rules[rule](rule, data[rule])
         if element is not None:
-            output.append(element)
+            # Handle multiple elements coming from a rule
+            if isinstance(element, tuple):
+                for e in element:
+                    output.append(e)
+            else:
+                output.append(element)
 
     return output
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,10 +187,10 @@ def xsd42():
 def minimal_json42():
     """Minimal valid JSON for DataCite 4.2."""
     return {
-        'identifier': {
+        'identifiers': [{
             'identifierType': 'DOI',
             'identifier': '10.1234/foo.bar',
-        },
+        }],
         'creators': [
             {'name': 'Nielsen, Lars Holm'},
         ],

--- a/tests/data/4.2/datacite-example-Box_dateCollected_DataCollector-v4.json
+++ b/tests/data/4.2/datacite-example-Box_dateCollected_DataCollector-v4.json
@@ -9,19 +9,24 @@
     "bibtex": "article",
     "ris": "RPRT"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Peach, A.",
-    "givenName": "A.",
-    "familyName": "Peach"
-  }],
-  "titles": [{
-    "title": "Temperature and Humidity in School Classrooms, Ponhook Lake, N.S., 1961-1962",
-    "lang": "en"
-  }],
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Peach, A.",
+      "givenName": "A.",
+      "familyName": "Peach"
+    }
+  ],
+  "titles": [
+    {
+      "title": "Temperature and Humidity in School Classrooms, Ponhook Lake, N.S., 1961-1962",
+      "lang": "en"
+    }
+  ],
   "publisher": "National Research Council Canada",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Temperature",
       "subjectScheme": "LCCN",
       "schemeUri": "http://lccn.loc.gov/sh85062931",
@@ -44,14 +49,17 @@
       "lang": "en"
     }
   ],
-  "contributors": [{
-    "nameType": "Personal",
-    "name": "Pomegranate, B.",
-    "givenName": "B.",
-    "familyName": "Pomegranate",
-    "contributorType": "DataCollector"
-  }],
-  "dates": [{
+  "contributors": [
+    {
+      "nameType": "Personal",
+      "name": "Pomegranate, B.",
+      "givenName": "B.",
+      "familyName": "Pomegranate",
+      "contributorType": "DataCollector"
+    }
+  ],
+  "dates": [
+    {
       "date": "1961-06-01/1962-10-12",
       "dateType": "Collected"
     },
@@ -62,39 +70,37 @@
   ],
   "publicationYear": "1963",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/datacollector_datecollected_geolocationbox"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/datacollector_datecollected_geolocationbox"
+    }
+  ],
   "sizes": [
     "10 p."
   ],
-  "formats": [
-
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [
+    {
+      "description": "The Division has been taking records of temperatures and humidities in groups of houses at various locations in Canada over the past several years. This survey has more recently been extended to include schools. Records obtained from classrooms in\n      six schools in Ponhook Lake, Nova Scotia from June 1, 1961-October 12, 1962 are now reported.",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
   ],
-  "rightsList": [
-
+  "geoLocations": [
+    {
+      "geoLocationBox": {
+        "westBoundLongitude": "-64.2",
+        "eastBoundLongitude": "-63.8",
+        "southBoundLatitude": "44.7167",
+        "northBoundLatitude": "44.9667"
+      },
+      "geoLocationPlace": "Ponhook Lake, Nova Scotia"
+    }
   ],
-  "descriptions": [{
-    "description": "The Division has been taking records of temperatures and humidities in groups of houses at various locations in Canada over the past several years. This survey has more recently been extended to include schools. Records obtained from classrooms in\n      six schools in Ponhook Lake, Nova Scotia from June 1, 1961-October 12, 1962 are now reported.",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [{
-    "geoLocationBox": {
-      "westBoundLongitude": "-64.2",
-      "eastBoundLongitude": "-63.8",
-      "southBoundLatitude": "44.7167",
-      "northBoundLatitude": "44.9667"
-    },
-    "geoLocationPlace": "Ponhook Lake, Nova Scotia"
-  }],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [
-
-  ],
+  "fundingReferences": [],
+  "relatedIdentifiers": [],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-DateRange-v4.json
+++ b/tests/data/4.2/datacite-example-DateRange-v4.json
@@ -1,0 +1,313 @@
+{
+  "alternateIdentifiers": [
+    {
+      "alternateIdentifier": "GGG2014",
+      "alternateIdentifierType": "Software_Version"
+    },
+    {
+      "alternateIdentifier": "ae",
+      "alternateIdentifierType": "id"
+    },
+    {
+      "alternateIdentifier": "ascension01",
+      "alternateIdentifierType": "longName"
+    },
+    {
+      "alternateIdentifier": "R0",
+      "alternateIdentifierType": "Data_Revision"
+    },
+    {
+      "alternateIdentifier": "210",
+      "alternateIdentifierType": "CaltechDATA_Identifier"
+    }
+  ],
+  "schemaVersion": "http://datacite.org/schema/kernel-4",
+  "contributors": [
+    {
+      "name": "California Institute of Techonolgy, Pasadena, CA (US)",
+      "contributorType": "HostingInstitution",
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "grid.20861.3d",
+          "nameIdentifierScheme": "GRID"
+        }
+      ]
+    },
+    {
+      "name": "Roehl, C. M.",
+      "contributorType": "DataCurator",
+      "affiliation": [
+        "California Institute of Technology, Pasadena, CA (US)"
+      ],
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "0000-0001-5383-8462",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
+    },
+    {
+      "name": "Dietrich Feist",
+      "contributorType": "ContactPerson"
+    },
+    {
+      "name": "TCCON",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "creators": [
+    {
+      "affiliation": [
+        "Max Planck Institute for Biogeochemistry, Jena (DE)"
+      ],
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "0000-0002-5890-6687",
+          "nameIdentifierScheme": "ORCID"
+        },
+        {
+          "nameIdentifier": "B-6489-2013",
+          "nameIdentifierScheme": "ResearcherID"
+        }
+      ],
+      "name": "Feist, D. G."
+    },
+    {
+      "affiliation": [
+        "Max Planck Institute for Biogeochemistry, Jena (DE)"
+      ],
+      "name": "Arnold, S. G."
+    },
+    {
+      "affiliation": [
+        "Ariane Tracking Station, Ascension Island (SH)"
+      ],
+      "name": "John, N."
+    },
+    {
+      "affiliation": [
+        "Stockholm University, Stockholm (SE)"
+      ],
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "0000-0002-7369-0781",
+          "nameIdentifierScheme": "ORCID"
+        },
+        {
+          "nameIdentifier": "B-8591-2015",
+          "nameIdentifierScheme": "ResearcherID"
+        }
+      ],
+      "name": "Geibel, M. C."
+    }
+  ],
+  "descriptions": [
+    {
+      "descriptionType": "Abstract",
+      "description": "The Total Carbon Column Observing Network (TCCON) is a network of ground-based Fourier Transform Spectrometers that record direct solar absorption spectra of the atmosphere in the near-infrared. From these spectra, accurate and precise column-averaged abundances of atmospheric constituents including CO2, CH4, N2O, HF, CO, H2O, and HDO, are retrieved. This data set contains observations from the TCCON station on Ascension Island."
+    },
+    {
+      "descriptionType": "Other",
+      "description": "<br>Cite this record as:<br>Feist, D. G., Arnold, S. G., John, N., &amp; Geibel, M. C. (2017). <i>TCCON data from Ascension Island (SH), Release GGG2014.R0</i> [Data set]. CaltechDATA. <a href=\"https://doi.org/10.14291/tccon.ggg2014.ascension01.r0/1149285\">https://doi.org/10.14291/tccon.ggg2014.ascension01.r0/1149285</a><br> or choose a <a href=\"https://crosscite.org/?doi=10.14291/tccon.ggg2014.ascension01.R0/1149285\"> different citation style.</a><br><a href=\"https://data.datacite.org/application/x-bibtex/10.14291/tccon.ggg2014.ascension01.R0/1149285\">Download Citation</a><br>"
+    },
+    {
+      "descriptionType": "Other",
+      "description": "<br>Unique Views: 433<br>Unique Downloads: 95<br> between February 21, 2017 and August 01, 2019<br><a href=\"https://data.caltech.edu/stats\">More info on how stats are collected</a><br>"
+    }
+  ],
+  "fundingReferences": [
+    {
+      "funderIdentifier": "grid.4372.2",
+      "funderIdentifierType": "GRID",
+      "funderName": "Max Planck Society"
+    },
+    {
+      "funderIdentifier": "grid.419500.9",
+      "funderIdentifierType": "GRID",
+      "funderName": "Max Planck Institute for Biogeochemistry"
+    }
+  ],
+  "language": "eng",
+  "publicationYear": "2014",
+  "publisher": "CaltechDATA",
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "10.14291/tccon.ggg2014.documentation.R0/1221662",
+      "relationType": "IsDocumentedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-9-683-2016",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.1002/2015JD023389",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/acp-16-1653-2016",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-9-3491-2016",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-9-2381-2016",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.1002/2015JD024157",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "https://tccon-wiki.caltech.edu/Network_Policy/Data_Use_Policy/Data_Description",
+      "relationType": "IsDocumentedBy",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relatedIdentifier": "https://tccon-wiki.caltech.edu/Sites",
+      "relationType": "IsDocumentedBy",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relatedIdentifier": "10.14291/TCCON.GGG2014",
+      "relationType": "IsPartOf",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "http://tccondata.org",
+      "relationType": "IsPartOf",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relatedIdentifier": "10.1038/s41598-017-13459-0",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.3390/rs9101033",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/acp-17-4781-2017",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-10-2209-2017",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-9-1415-2016",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-11-3111-2018",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relatedIdentifier": "10.5194/amt-10-4135-2017",
+      "relationType": "IsCitedBy",
+      "relatedIdentifierType": "DOI"
+    }
+  ],
+  "resourceType": {
+    "resourceTypeGeneral": "Dataset"
+  },
+  "types": {
+    "resourceTypeGeneral": "Dataset",
+    "resourceType": "Dataset"
+  },
+  "rightsList": [
+    {
+      "rights": "TCCON Data Use Policy",
+      "rightsURI": "https://data.caltech.edu/tindfiles/serve/cb9b01e4-56ea-4b8c-9543-0c61d0c72148/"
+    }
+  ],
+  "subjects": [
+    {
+      "subject": "atmospheric trace gases"
+    },
+    {
+      "subject": "CO2"
+    },
+    {
+      "subject": "CH4"
+    },
+    {
+      "subject": "CO"
+    },
+    {
+      "subject": "N2O"
+    },
+    {
+      "subject": "column-averaged dry-air mole fractions"
+    },
+    {
+      "subject": "remote sensing"
+    },
+    {
+      "subject": "FTIR spectroscopy"
+    },
+    {
+      "subject": "TCCON"
+    }
+  ],
+  "titles": [
+    {
+      "title": "TCCON data from Ascension Island (SH), Release GGG2014.R0"
+    }
+  ],
+  "version": "GGG2014.R0",
+  "identifiers": [
+    {
+      "identifier": "10.14291/tccon.ggg2014.ascension01.R0/1149285",
+      "identifierType": "DOI"
+    }
+  ],
+  "formats": [
+    "application/x-netcdf"
+  ],
+  "dates": [
+    {
+      "date": "2014-10-01",
+      "dateType": "Created"
+    },
+    {
+      "date": "2014-10-10",
+      "dateType": "Issued"
+    },
+    {
+      "date": "2019-08-01",
+      "dateType": "Updated"
+    },
+    {
+      "date": "2012-05-22/2018-10-31",
+      "dateType": "Collected"
+    },
+    {
+      "date": "2017-02-21",
+      "dateType": "Submitted"
+    }
+  ],
+  "geoLocations": [
+    {
+      "geoLocationPlace": "Ariane Tracking Station (AC)",
+      "geoLocationPoint": {
+        "pointLatitude": "-7.9165",
+        "pointLongitude": "-14.3325"
+      }
+    }
+  ]
+}

--- a/tests/data/4.2/datacite-example-DateRange-v4.xml
+++ b/tests/data/4.2/datacite-example-DateRange-v4.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.14291/TCCON.GGG2014.ASCENSION01.R0/1149285</identifier>
+  <creators>
+    <creator>
+      <creatorName>Feist, D. G.</creatorName>
+      <nameIdentifier nameIdentifierScheme="ORCID">0000-0002-5890-6687</nameIdentifier>
+      <nameIdentifier nameIdentifierScheme="ResearcherID">B-6489-2013</nameIdentifier>
+      <affiliation>Max Planck Institute for Biogeochemistry, Jena (DE)</affiliation>
+    </creator>
+    <creator>
+      <creatorName>Arnold, S. G.</creatorName>
+      <affiliation>Max Planck Institute for Biogeochemistry, Jena (DE)</affiliation>
+    </creator>
+    <creator>
+      <creatorName>John, N.</creatorName>
+      <affiliation>Ariane Tracking Station, Ascension Island (SH)</affiliation>
+    </creator>
+    <creator>
+      <creatorName>Geibel, M. C.</creatorName>
+      <nameIdentifier nameIdentifierScheme="ORCID">0000-0002-7369-0781</nameIdentifier>
+      <nameIdentifier nameIdentifierScheme="ResearcherID">B-8591-2015</nameIdentifier>
+      <affiliation>Stockholm University, Stockholm (SE)</affiliation>
+    </creator>
+  </creators>
+  <titles>
+    <title>TCCON data from Ascension Island (SH), Release GGG2014.R0</title>
+  </titles>
+  <publisher>CaltechDATA</publisher>
+  <publicationYear>2017</publicationYear>
+  <subjects>
+    <subject>atmospheric trace gases</subject>
+    <subject>CO2</subject>
+    <subject>CH4</subject>
+    <subject>CO</subject>
+    <subject>N2O</subject>
+    <subject>column-averaged dry-air mole fractions</subject>
+    <subject>remote sensing</subject>
+    <subject>FTIR spectroscopy</subject>
+    <subject>TCCON</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="HostingInstitution">
+      <contributorName>California Institute of Techonolgy, Pasadena, CA (US)</contributorName>
+      <nameIdentifier nameIdentifierScheme="GRID">grid.20861.3d</nameIdentifier>
+    </contributor>
+    <contributor contributorType="DataCurator">
+      <contributorName>Roehl, C. M.</contributorName>
+      <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-5383-8462</nameIdentifier>
+      <affiliation>California Institute of Technology, Pasadena, CA (US)</affiliation>
+    </contributor>
+    <contributor contributorType="ContactPerson">
+      <contributorName>Dietrich Feist</contributorName>
+    </contributor>
+    <contributor contributorType="ResearchGroup">
+      <contributorName>TCCON</contributorName>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Created">2014-10-01</date>
+    <date dateType="Issued">2014-10-10</date>
+    <date dateType="Updated">2019-08-01</date>
+    <date dateType="Collected">2012-05-22/2018-10-31</date>
+    <date dateType="Submitted">2017-02-21</date>
+  </dates>
+  <language>eng</language>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="Software_Version">GGG2014</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="id">ae</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="longName">ascension01</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="Data_Revision">R0</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+    <alternateIdentifier alternateIdentifierType="CaltechDATA_Identifier">210</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsDocumentedBy">10.14291/tccon.ggg2014.documentation.R0/1221662</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-9-683-2016</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/2015JD023389</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/acp-16-1653-2016</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-9-3491-2016</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-9-2381-2016</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/2015JD024157</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsDocumentedBy">https://tccon-wiki.caltech.edu/Network_Policy/Data_Use_Policy/Data_Description</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsDocumentedBy">https://tccon-wiki.caltech.edu/Sites</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsPartOf">10.14291/TCCON.GGG2014</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">http://tccondata.org</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1038/s41598-017-13459-0</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.3390/rs9101033</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/acp-17-4781-2017</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-10-2209-2017</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-9-1415-2016</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-11-3111-2018</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.5194/amt-10-4135-2017</relatedIdentifier>
+  </relatedIdentifiers>
+  <formats>
+    <format>application/x-netcdf</format>
+  </formats>
+  <version>GGG2014.R0</version>
+  <rightsList>
+    <rights rightsURI="https://data.caltech.edu/tindfiles/serve/cb9b01e4-56ea-4b8c-9543-0c61d0c72148/">TCCON Data Use Policy</rights>
+  </rightsList>
+  <descriptions>
+    <description descriptionType="Abstract">The Total Carbon Column Observing Network (TCCON) is a network of ground-based Fourier Transform Spectrometers that record direct solar absorption spectra of the atmosphere in the near-infrared. From these spectra, accurate and precise column-averaged abundances of atmospheric constituents including CO2, CH4, N2O, HF, CO, H2O, and HDO, are retrieved. This data set contains observations from the TCCON station on Ascension Island.</description>
+    <description descriptionType="Other">&lt;br&gt;Cite this record as:&lt;br&gt;Feist, D. G., Arnold, S. G., John, N., &amp;amp; Geibel, M. C. (2017). &lt;i&gt;TCCON data from Ascension Island (SH), Release GGG2014.R0&lt;/i&gt; [Data set]. CaltechDATA. &lt;a href="https://doi.org/10.14291/tccon.ggg2014.ascension01.r0/1149285"&gt;https://doi.org/10.14291/tccon.ggg2014.ascension01.r0/1149285&lt;/a&gt;&lt;br&gt; or choose a &lt;a href="https://crosscite.org/?doi=10.14291/tccon.ggg2014.ascension01.R0/1149285"&gt; different citation style.&lt;/a&gt;&lt;br&gt;&lt;a href="https://data.datacite.org/application/x-bibtex/10.14291/tccon.ggg2014.ascension01.R0/1149285"&gt;Download Citation&lt;/a&gt;&lt;br&gt;</description>
+    <description descriptionType="Other">&lt;br&gt;Unique Views: 422&lt;br&gt;Unique Downloads: 93&lt;br&gt; between February 21, 2017 and July 19, 2019&lt;br&gt;&lt;a href="https://data.caltech.edu/stats"&gt;More info on how stats are collected&lt;/a&gt;&lt;br&gt;</description>
+  </descriptions>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>Max Planck Society</funderName>
+      <funderIdentifier funderIdentifierType="GRID">grid.4372.2</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
+      <funderName>Max Planck Institute for Biogeochemistry</funderName>
+      <funderIdentifier funderIdentifierType="GRID">grid.419500.9</funderIdentifier>
+    </fundingReference>
+  </fundingReferences>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPlace>Ariane Tracking Station (AC)</geoLocationPlace>
+      <geoLocationPoint>
+        <pointLongitude>-14.3325</pointLongitude>
+        <pointLatitude>-7.9165</pointLatitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>

--- a/tests/data/4.2/datacite-example-GeoLocation-v4.json
+++ b/tests/data/4.2/datacite-example-GeoLocation-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "misc",
     "ris": "DATA"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Schumann, Kai",
       "givenName": "Kai",
@@ -28,63 +29,79 @@
       "familyName": "Weinrebe"
     }
   ],
-  "titles": [{
-    "title": "Gridded results of swath bathymetric mapping of Disko Bay, Western Greenland, 2007-2008",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Gridded results of swath bathymetric mapping of Disko Bay, Western Greenland, 2007-2008",
+      "lang": "en"
+    }
+  ],
   "publisher": "PANGAEA - Data Publisher for Earth & Environmental Science",
   "container": {},
-  "subjects": [{
-    "subject": "551 Geology, hydrology, meteorology",
-    "subjectScheme": "DDC",
-    "lang": "en"
-  }],
-  "contributors": [{
-    "nameType": "Organizational",
-    "name": "IFM-GEOMAR Leibniz-Institute Of Marine Sciences, Kiel University",
-    "contributorType": "ResearchGroup"
-  }],
-  "dates": [{
-    "date": "2011",
-    "dateType": "Issued"
-  }],
+  "subjects": [
+    {
+      "subject": "551 Geology, hydrology, meteorology",
+      "subjectScheme": "DDC",
+      "lang": "en"
+    }
+  ],
+  "contributors": [
+    {
+      "nameType": "Organizational",
+      "name": "IFM-GEOMAR Leibniz-Institute Of Marine Sciences, Kiel University",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "dates": [
+    {
+      "date": "2011",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2011",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/geopointexample"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/geopointexample"
+    }
+  ],
   "sizes": [
     "4 datasets"
   ],
   "formats": [
     "application/zip"
   ],
-  "rightsList": [{
-    "rights": "Creative Commons Attribution-NoDerivs 2.0 Generic",
-    "rightsUri": "http://creativecommons.org/licenses/by/3.0/deed",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
-    "description": "A ship-based acoustic mapping campaign was conducted at the exit of Ilulissat Ice Fjord and in the sedimentary basin of Disko Bay to the west of the fjord mouth. Submarine landscape and sediment distribution patterns are interpreted in terms of\n      glaciomarine facies types that are related to variations in the past position of the glacier front. In particular, asymmetric ridges that form a curved entity and a large sill at the fjord mouth may represent moraines hat depict at least two\n      relatively stable positions of the ice front in the Disko Bay and at the fjord mouth. In this respect, Ilulissat Glacier shows prominent differences to the East Greenland Kangerlussuaq Glacier which is comparable in present size and present role for\n      the ice discharge from the inland ice sheet. Two linear clusters of pockmarks in the center of the sedimentary basin seem to be linked to ongoing methane release due to dissociation of gas hydrates, a process fueled by climate warming in the Arctic\n      realm.",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [{
-    "geoLocationPoint": {
-      "pointLatitude": "69.000000",
-      "pointLongitude": "-52.000000"
-    },
-    "geoLocationPlace": "Disko Bay"
-  }],
-  "fundingReferences": [
-
+  "rightsList": [
+    {
+      "rights": "Creative Commons Attribution-NoDerivs 2.0 Generic",
+      "rightsUri": "http://creativecommons.org/licenses/by/3.0/deed",
+      "lang": "en-US"
+    }
   ],
-  "relatedIdentifiers": [{
-    "relatedIdentifier": "10.5072/timeseries",
-    "relatedIdentifierType": "DOI",
-    "relationType": "Continues"
-  }],
+  "descriptions": [
+    {
+      "description": "A ship-based acoustic mapping campaign was conducted at the exit of Ilulissat Ice Fjord and in the sedimentary basin of Disko Bay to the west of the fjord mouth. Submarine landscape and sediment distribution patterns are interpreted in terms of\n      glaciomarine facies types that are related to variations in the past position of the glacier front. In particular, asymmetric ridges that form a curved entity and a large sill at the fjord mouth may represent moraines hat depict at least two\n      relatively stable positions of the ice front in the Disko Bay and at the fjord mouth. In this respect, Ilulissat Glacier shows prominent differences to the East Greenland Kangerlussuaq Glacier which is comparable in present size and present role for\n      the ice discharge from the inland ice sheet. Two linear clusters of pockmarks in the center of the sedimentary basin seem to be linked to ongoing methane release due to dissociation of gas hydrates, a process fueled by climate warming in the Arctic\n      realm.",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
+  ],
+  "geoLocations": [
+    {
+      "geoLocationPoint": {
+        "pointLatitude": "69.000000",
+        "pointLongitude": "-52.000000"
+      },
+      "geoLocationPlace": "Disko Bay"
+    }
+  ],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "10.5072/timeseries",
+      "relatedIdentifierType": "DOI",
+      "relationType": "Continues"
+    }
+  ],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-HasMetadata-v4.json
+++ b/tests/data/4.2/datacite-example-HasMetadata-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "article",
     "ris": "RPRT"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Mari, Bernard",
       "givenName": "Bernard",
@@ -34,13 +35,16 @@
       "familyName": "Lebrigand"
     }
   ],
-  "titles": [{
-    "title": "Identification of putative novel specific targets of mir-210 in A549 human adenocarcinoma cells",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Identification of putative novel specific targets of mir-210 in A549 human adenocarcinoma cells",
+      "lang": "en"
+    }
+  ],
   "publisher": "Institut de Pharmacologie Moleculaire et Cellulaire (IPMC), CNRS UMR6097, Universite de Nice Sophia-Antipolis, 660 route des lucioles, 06560 Valbonne - Sophia-Antipolis, France",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Neoplasms",
       "subjectScheme": "Mesh",
       "schemeUri": "http://www.nlm.nih.gov/mesh/meshhome.html"
@@ -66,21 +70,27 @@
       "schemeUri": "http://purl.obolibrary.org/obo/obi"
     }
   ],
-  "contributors": [{
-    "nameType": "Organizational",
-    "name": "INIST-CNRS",
-    "contributorType": "ResearchGroup"
-  }],
-  "dates": [{
-    "date": "2010",
-    "dateType": "Issued"
-  }],
+  "contributors": [
+    {
+      "nameType": "Organizational",
+      "name": "INIST-CNRS",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "dates": [
+    {
+      "date": "2010",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2010",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/example"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/example"
+    }
+  ],
   "sizes": [
     "183 ko",
     "3 pages"
@@ -88,29 +98,31 @@
   "formats": [
     "PDF"
   ],
-  "rightsList": [{
-    "rightsUri": "http://creativecommons.org/licenses/by-nc-nd/3.0",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
-    "description": "To identify putative novel specific targets of mir-210, we overexpressed miR-210 as well as miR-34a and a siRNA targeted against E2F3 in A549 human adenocarcinoma cells by transfecting them with synthetic pre-miRNAs or a synthetic negative pre-miRNA\n      as control (miR-Neg). RNA samples were harvested at 48 hours post-transfection and 2 independent experiments performed in dye-swap: miR-210 versus miR-Neg ; miR-34a versus miR-Neg ; si-E2F3 versus miR-Neg ; si-control versus miR-Neg.",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [
-
+  "rightsList": [
+    {
+      "rightsUri": "http://creativecommons.org/licenses/by-nc-nd/3.0",
+      "lang": "en-US"
+    }
   ],
-  "fundingReferences": [
-
+  "descriptions": [
+    {
+      "description": "To identify putative novel specific targets of mir-210, we overexpressed miR-210 as well as miR-34a and a siRNA targeted against E2F3 in A549 human adenocarcinoma cells by transfecting them with synthetic pre-miRNAs or a synthetic negative pre-miRNA\n      as control (miR-Neg). RNA samples were harvested at 48 hours post-transfection and 2 independent experiments performed in dye-swap: miR-210 versus miR-Neg ; miR-34a versus miR-Neg ; si-E2F3 versus miR-Neg ; si-control versus miR-Neg.",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
   ],
-  "relatedIdentifiers": [{
-    "relatedIdentifier": "http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE18695",
-    "relatedIdentifierType": "URL",
-    "relationType": "HasMetadata",
-    "relatedMetadataScheme": "ISA-Tab",
-    "schemeUri": "http://isatab.sourceforge.net/docs/ISA-TAB_release-candidate-1_v1.0_24nov08.pdf",
-    "schemeType": "Text"
-  }],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE18695",
+      "relatedIdentifierType": "URL",
+      "relationType": "HasMetadata",
+      "relatedMetadataScheme": "ISA-Tab",
+      "schemeUri": "http://isatab.sourceforge.net/docs/ISA-TAB_release-candidate-1_v1.0_24nov08.pdf",
+      "schemeType": "Text"
+    }
+  ],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-ResearchGroup_Methods-v4.json
+++ b/tests/data/4.2/datacite-example-ResearchGroup_Methods-v4.json
@@ -9,23 +9,30 @@
     "bibtex": "misc",
     "ris": "DATA"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Rizk-Jackson, Angela",
-    "givenName": "Angela",
-    "familyName": "Rizk-Jackson",
-    "nameIdentifiers": [{
-      "nameIdentifier": "https://orcid.org/0000-0002-1732-8550",
-      "nameIdentifierScheme": "ORCID"
-    }]
-  }],
-  "titles": [{
-    "title": "Analysis of ADNI data: Normal to MCI conversion",
-    "lang": "en"
-  }],
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Rizk-Jackson, Angela",
+      "givenName": "Angela",
+      "familyName": "Rizk-Jackson",
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "https://orcid.org/0000-0002-1732-8550",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "title": "Analysis of ADNI data: Normal to MCI conversion",
+      "lang": "en"
+    }
+  ],
   "publisher": "University of California, San Francisco",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Aging",
       "lang": "en"
     },
@@ -50,30 +57,31 @@
       "lang": "en"
     }
   ],
-  "contributors": [{
-    "nameType": "Organizational",
-    "name": "Center For Imaging Of Neurodegenerative Disease",
-    "contributorType": "ResearchGroup"
-  }],
-  "dates": [{
-    "date": "2013",
-    "dateType": "Issued"
-  }],
+  "contributors": [
+    {
+      "nameType": "Organizational",
+      "name": "Center For Imaging Of Neurodegenerative Disease",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "dates": [
+    {
+      "date": "2013",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2013",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/fk25h7qrs"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/fk25h7qrs"
+    }
   ],
-  "formats": [
-
-  ],
-  "rightsList": [
-
-  ],
-  "descriptions": [{
+  "sizes": [],
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [
+    {
       "description": "This study replication data resource includes information referencing specific items in the Alzheimer's Disease Neuroimaging Initiative (ADNI) database that were used with the included analysis scripts (R statistical software) to reach conclusions\n      presented in the referenced publication (DOI: 10.1016/j.jalz.2012.05.911).",
       "descriptionType": "Abstract",
       "lang": "en"
@@ -84,17 +92,15 @@
       "lang": "en"
     }
   ],
-  "geoLocations": [
-
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "10.5072/j.jalz.2012.05.911",
+      "relatedIdentifierType": "DOI",
+      "relationType": "IsReferencedBy"
+    }
   ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [{
-    "relatedIdentifier": "10.5072/j.jalz.2012.05.911",
-    "relatedIdentifierType": "DOI",
-    "relationType": "IsReferencedBy"
-  }],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-ResourceTypeGeneral_Collection-v4.json
+++ b/tests/data/4.2/datacite-example-ResourceTypeGeneral_Collection-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "misc",
     "ris": "GEN"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Barton, T.",
       "givenName": "T.",
@@ -22,13 +23,16 @@
       "familyName": "Bowler"
     }
   ],
-  "titles": [{
-    "title": "Archaeological Evaluation, 64 Kenneth Street, Stornoway Isle of Lewis",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Archaeological Evaluation, 64 Kenneth Street, Stornoway Isle of Lewis",
+      "lang": "en"
+    }
+  ],
   "publisher": "Scottish Urban Archaeological Trust Ltd.",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Archaeology",
       "lang": "en"
     },
@@ -37,19 +41,29 @@
       "lang": "en"
     }
   ],
-  "contributors": [
-
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2008",
+      "dateType": "Issued"
+    }
   ],
-  "dates": [{
-    "date": "2008",
-    "dateType": "Issued"
-  }],
   "publicationYear": "2008",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/1003496"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/1003496"
+    },
+    {
+      "identifierType": "ADS Grey Lit ID",
+      "identifier": "4335"
+    },
+    {
+      "identifierType": "OASIS ID",
+      "identifier": "suatltd1-48159"
+    }
+  ],
   "sizes": [
     "Doc: 46 kb",
     "PDF: 750 kb",
@@ -60,25 +74,27 @@
     "application/pdf",
     "image/jpeg"
   ],
-  "rightsList": [{
-    "rights": "Terms of Use and Access to ADS Resources",
-    "rightsUri": "http://archaeologydataservice.ac.uk/advice/termsOfUseAndAccess",
-    "lang": "en"
-  }],
-  "descriptions": [{
-    "description": "Unpublished fieldwork reports (Grey Literature Library)",
-    "descriptionType": "Other",
-    "lang": "en"
-  }],
-  "geoLocations": [{
-    "geoLocationPlace": "Stornoway, Western Isles, Scotland"
-  }],
-  "fundingReferences": [
-
+  "rightsList": [
+    {
+      "rights": "Terms of Use and Access to ADS Resources",
+      "rightsUri": "http://archaeologydataservice.ac.uk/advice/termsOfUseAndAccess",
+      "lang": "en"
+    }
   ],
-  "relatedIdentifiers": [
-
+  "descriptions": [
+    {
+      "description": "Unpublished fieldwork reports (Grey Literature Library)",
+      "descriptionType": "Other",
+      "lang": "en"
+    }
   ],
+  "geoLocations": [
+    {
+      "geoLocationPlace": "Stornoway, Western Isles, Scotland"
+    }
+  ],
+  "fundingReferences": [],
+  "relatedIdentifiers": [],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-complicated-v4.json
+++ b/tests/data/4.2/datacite-example-complicated-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "book",
     "ris": "BOOK"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Smith, John",
       "givenName": "John",
@@ -19,7 +20,8 @@
       "name": "つまらないものですが"
     }
   ],
-  "titles": [{
+  "titles": [
+    {
       "title": "Właściwości rzutowań podprzestrzeniowych",
       "lang": "pl"
     },
@@ -35,7 +37,8 @@
     "identifier": "10.5272/oldertestpub",
     "identifierType": "DOI"
   },
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "830 German &amp; related literatures",
       "subjectScheme": "DDC",
       "lang": "en"
@@ -45,27 +48,39 @@
       "lang": "en"
     }
   ],
-  "contributors": [{
-    "nameType": "Personal",
-    "name": "Doe, John",
-    "givenName": "John",
-    "familyName": "Doe",
-    "nameIdentifiers": [{
-      "nameIdentifier": "https://orcid.org/0000-0001-5393-1421",
-      "nameIdentifierScheme": "ORCID"
-    }],
-    "contributorType": "DataCollector"
-  }],
-  "dates": [{
-    "date": "2010",
-    "dateType": "Issued"
-  }],
+  "contributors": [
+    {
+      "nameType": "Personal",
+      "name": "Doe, John",
+      "givenName": "John",
+      "familyName": "Doe",
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "https://orcid.org/0000-0001-5393-1421",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ],
+      "contributorType": "DataCollector"
+    }
+  ],
+  "dates": [
+    {
+      "date": "2010",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2010",
   "language": "de",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/testpub"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/testpub"
+    },
+    {
+      "identifierType": "ISBN",
+      "identifier": "937-0-4523-12357-6"
+    }
+  ],
   "sizes": [
     "256 pages"
   ],
@@ -73,26 +88,28 @@
     "pdf"
   ],
   "version": "2",
-  "rightsList": [{
-    "rightsUri": "http://creativecommons.org/licenses/by-nd/2.0",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
-    "description": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea\n      takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores\n      et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
-    "descriptionType": "Abstract",
-    "lang": "la"
-  }],
-  "geoLocations": [
-
+  "rightsList": [
+    {
+      "rightsUri": "http://creativecommons.org/licenses/by-nd/2.0",
+      "lang": "en-US"
+    }
   ],
-  "fundingReferences": [
-
+  "descriptions": [
+    {
+      "description": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea\n      takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores\n      et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "descriptionType": "Abstract",
+      "lang": "la"
+    }
   ],
-  "relatedIdentifiers": [{
-    "relatedIdentifier": "10.5272/oldertestpub",
-    "relatedIdentifierType": "DOI",
-    "relationType": "IsPartOf"
-  }],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "10.5272/oldertestpub",
+      "relatedIdentifierType": "DOI",
+      "relationType": "IsPartOf"
+    }
+  ],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-datapaper-v4.json
+++ b/tests/data/4.2/datacite-example-datapaper-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "misc",
     "ris": "DATA"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Hammond, Mark D",
       "givenName": "Mark D",
@@ -22,10 +23,12 @@
       "familyName": "Jones"
     }
   ],
-  "titles": [{
-    "title": "Freshwater flux from ice sheet melting and iceberg calving in the Southern Ocean",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Freshwater flux from ice sheet melting and iceberg calving in the Southern Ocean",
+      "lang": "en"
+    }
+  ],
   "publisher": "Royal Meteorological Society",
   "container": {
     "type": "Series",
@@ -33,7 +36,8 @@
     "volume": "Volume 3",
     "firstPage": "Issue 2 November 2016  Pages 60–62"
   },
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "freshwater",
       "lang": "en"
     },
@@ -50,29 +54,26 @@
       "lang": "en"
     }
   ],
-  "contributors": [
-
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2016",
+      "dateType": "Issued"
+    }
   ],
-  "dates": [{
-    "date": "2016",
-    "dateType": "Issued"
-  }],
   "publicationYear": "2016",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/example-datapaper"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/example-datapaper"
+    }
   ],
-  "formats": [
-
-  ],
-  "rightsList": [
-
-  ],
-  "descriptions": [{
+  "sizes": [],
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [
+    {
       "description": "This dataset is a multiyear mean Southern Ocean freshwater flux field that uses recently compiled measurements of ice sheet melting, iceberg calving, iceberg tracking, and river runoff",
       "descriptionType": "Abstract"
     },
@@ -81,17 +82,15 @@
       "descriptionType": "SeriesInformation"
     }
   ],
-  "geoLocations": [
-
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
+      "relatedIdentifier": "doi:10.5072/dataset",
+      "relatedIdentifierType": "DOI",
+      "relationType": "Describes"
+    }
   ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [{
-    "relatedIdentifier": "doi:10.5072/dataset",
-    "relatedIdentifierType": "DOI",
-    "relationType": "Describes"
-  }],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-dataset-v4.json
+++ b/tests/data/4.2/datacite-example-dataset-v4.json
@@ -36,8 +36,7 @@
     }
   ],
   "publisher": "Purdue University Research Repository (PURR)",
-  "container": {
-  },
+  "container": {},
   "subjects": [
     {
       "subject": "Assessment",
@@ -64,9 +63,7 @@
       "lang": "en"
     }
   ],
-  "contributors": [
-
-  ],
+  "contributors": [],
   "dates": [
     {
       "date": "2013",
@@ -75,22 +72,16 @@
   ],
   "publicationYear": "2013",
   "language": "en",
-  "identifier":
+  "identifiers": [
     {
       "identifierType": "DOI",
       "identifier": "10.5072/d3p26q35r-test"
     }
-  ,
-  "sizes": [
-
   ],
-  "formats": [
-
-  ],
+  "sizes": [],
+  "formats": [],
   "version": "1.0",
-  "rightsList": [
-
-  ],
+  "rightsList": [],
   "descriptions": [
     {
       "description": "We developed an instrument, Critical Engineering Literacy Test (CELT), which is a multiple choice instrument designed to measure undergraduate students’ scientific and information literacy skills. It requires students to first read a technical memo\n      and, based on the memo’s arguments, answer eight multiple choice and six open-ended response questions. We collected data from 143 first-year engineering students and conducted an item analysis. The KR-20 reliability of the instrument was .39. Item\n      difficulties ranged between .17 to .83. The results indicate low reliability index but acceptable levels of item difficulties and item discrimination indices. Students were most challenged when answering items measuring scientific and mathematical\n      literacy (i.e., identifying incorrect information).",
@@ -98,15 +89,9 @@
       "lang": "en"
     }
   ],
-  "geoLocations": [
-
-  ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [
-
-  ],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-full-v4.json
+++ b/tests/data/4.2/datacite-example-full-v4.json
@@ -9,18 +9,23 @@
     "bibtex": "misc",
     "ris": "COMP"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Miller, Elizabeth",
-    "givenName": "Elizabeth",
-    "familyName": "Miller",
-    "nameIdentifiers": [{
-      "nameIdentifier": "https://orcid.org/0000-0001-5000-0007",
-      "nameIdentifierScheme": "ORCID"
-    }],
-    "affiliation": "DataCite"
-  }],
-  "titles": [{
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Miller, Elizabeth",
+      "givenName": "Elizabeth",
+      "familyName": "Miller",
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "https://orcid.org/0000-0001-5000-0007",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ],
+      "affiliation": "DataCite"
+    }
+  ],
+  "titles": [
+    {
       "title": "Full DataCite XML Example",
       "lang": "en-US"
     },
@@ -32,25 +37,32 @@
   ],
   "publisher": "DataCite",
   "container": {},
-  "subjects": [{
-    "subject": "000 computer science",
-    "subjectScheme": "dewey",
-    "schemeUri": "http://dewey.info/",
-    "lang": "en-US"
-  }],
-  "contributors": [{
-    "nameType": "Personal",
-    "name": "Starr, Joan",
-    "givenName": "Joan",
-    "familyName": "Starr",
-    "nameIdentifiers": [{
-      "nameIdentifier": "https://orcid.org/0000-0002-7285-027X",
-      "nameIdentifierScheme": "ORCID"
-    }],
-    "affiliation": "California Digital Library",
-    "contributorType": "ProjectLeader"
-  }],
-  "dates": [{
+  "subjects": [
+    {
+      "subject": "000 computer science",
+      "subjectScheme": "dewey",
+      "schemeUri": "http://dewey.info/",
+      "lang": "en-US"
+    }
+  ],
+  "contributors": [
+    {
+      "nameType": "Personal",
+      "name": "Starr, Joan",
+      "givenName": "Joan",
+      "familyName": "Starr",
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "https://orcid.org/0000-0002-7285-027X",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ],
+      "affiliation": "California Digital Library",
+      "contributorType": "ProjectLeader"
+    }
+  ],
+  "dates": [
+    {
       "date": "2017-09-13",
       "dateType": "Updated",
       "dateInformation": "Updated with 4.2 properties"
@@ -62,10 +74,16 @@
   ],
   "publicationYear": "2014",
   "language": "en-US",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/example-full"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/example-full"
+    },
+    {
+      "identifierType": "URL",
+      "identifier": "https://schema.datacite.org/meta/kernel-4.2/example/datacite-example-full-v4.2.xml"
+    }
+  ],
   "sizes": [
     "4 kB"
   ],
@@ -73,67 +91,77 @@
     "application/xml"
   ],
   "version": "4.2",
-  "rightsList": [{
-    "rightsUri": "http://creativecommons.org/publicdomain/zero/1.0",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
-    "description": "XML example of all DataCite Metadata Schema v4.2 properties.",
-    "descriptionType": "Abstract",
-    "lang": "en-US"
-  }],
-  "geoLocations": [{
-    "geoLocationPoint": {
-      "pointLatitude": "31.233",
-      "pointLongitude": "-67.302"
-    },
-    "geoLocationBox": {
-      "westBoundLongitude": "-71.032",
-      "eastBoundLongitude": "-68.211",
-      "southBoundLatitude": "41.090",
-      "northBoundLatitude": "42.893"
-    },
-    "geoLocationPolygon": [{
-        "polygonPoint": {
-          "pointLatitude": "41.991",
-          "pointLongitude": "-71.032"
-        }
+  "rightsList": [
+    {
+      "rightsUri": "http://creativecommons.org/publicdomain/zero/1.0",
+      "lang": "en-US"
+    }
+  ],
+  "descriptions": [
+    {
+      "description": "XML example of all DataCite Metadata Schema v4.2 properties.",
+      "descriptionType": "Abstract",
+      "lang": "en-US"
+    }
+  ],
+  "geoLocations": [
+    {
+      "geoLocationPoint": {
+        "pointLatitude": "31.233",
+        "pointLongitude": "-67.302"
       },
-      {
-        "polygonPoint": {
-          "pointLatitude": "42.893",
-          "pointLongitude": "-69.622"
-        }
+      "geoLocationBox": {
+        "westBoundLongitude": "-71.032",
+        "eastBoundLongitude": "-68.211",
+        "southBoundLatitude": "41.090",
+        "northBoundLatitude": "42.893"
       },
-      {
-        "polygonPoint": {
-          "pointLatitude": "41.991",
-          "pointLongitude": "-68.211"
+      "geoLocationPolygon": [
+        {
+          "polygonPoint": {
+            "pointLatitude": "41.991",
+            "pointLongitude": "-71.032"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLatitude": "42.893",
+            "pointLongitude": "-69.622"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLatitude": "41.991",
+            "pointLongitude": "-68.211"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLatitude": "41.090",
+            "pointLongitude": "-69.622"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLatitude": "41.991",
+            "pointLongitude": "-71.032"
+          }
         }
-      },
-      {
-        "polygonPoint": {
-          "pointLatitude": "41.090",
-          "pointLongitude": "-69.622"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLatitude": "41.991",
-          "pointLongitude": "-71.032"
-        }
-      }
-    ],
-    "geoLocationPlace": "Atlantic Ocean"
-  }],
-  "fundingReferences": [{
-    "funderName": "National Science Foundation",
-    "funderIdentifier": "https://doi.org/10.13039/100000001",
-    "funderIdentifierType": "Crossref Funder ID",
-    "awardNumber": "CBET-106",
-    "awardTitle": "Full DataCite XML Example"
-  }],
-  "relatedIdentifiers": [{
+      ],
+      "geoLocationPlace": "Atlantic Ocean"
+    }
+  ],
+  "fundingReferences": [
+    {
+      "funderName": "National Science Foundation",
+      "funderIdentifier": "https://doi.org/10.13039/100000001",
+      "funderIdentifierType": "Crossref Funder ID",
+      "awardNumber": "CBET-106",
+      "awardTitle": "Full DataCite XML Example"
+    }
+  ],
+  "relatedIdentifiers": [
+    {
       "relatedIdentifier": "https://data.datacite.org/application/citeproc+json/10.5072/example-full",
       "relatedIdentifierType": "URL",
       "relationType": "HasMetadata",

--- a/tests/data/4.2/datacite-example-fundingReference-v4.json
+++ b/tests/data/4.2/datacite-example-fundingReference-v4.json
@@ -9,20 +9,25 @@
     "bibtex": "misc",
     "ris": "DATA"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Dedeurwaerdere, Tom",
-    "givenName": "Tom",
-    "familyName": "Dedeurwaerdere",
-    "affiliation": "Université catholique de Louvain"
-  }],
-  "titles": [{
-    "title": "Combining internal and external motivations in multi-actor governance arrangements for biodiversity and ecosystem services",
-    "lang": "en"
-  }],
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Dedeurwaerdere, Tom",
+      "givenName": "Tom",
+      "familyName": "Dedeurwaerdere",
+      "affiliation": "Université catholique de Louvain"
+    }
+  ],
+  "titles": [
+    {
+      "title": "Combining internal and external motivations in multi-actor governance arrangements for biodiversity and ecosystem services",
+      "lang": "en"
+    }
+  ],
   "publisher": "Zenodo",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Internal motivations",
       "lang": "en"
     },
@@ -43,25 +48,28 @@
       "lang": "en"
     }
   ],
-  "contributors": [
-
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2016-03-11",
+      "dateType": "Issued"
+    }
   ],
-  "dates": [{
-    "date": "2016-03-11",
-    "dateType": "Issued"
-  }],
   "publicationYear": "2016",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5281/zenodo.47394"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5281/zenodo.47394"
+    },
+    {
+      "identifierType": "URL",
+      "identifier": "http://zenodo.org/record/47394"
+    }
   ],
-  "formats": [
-
-  ],
-  "rightsList": [{
+  "sizes": [],
+  "formats": [],
+  "rightsList": [
+    {
       "rights": "Open Access",
       "rightsUri": "info:eu-repo/semantics/openAccess"
     },
@@ -70,15 +78,16 @@
       "rightsUri": "http://creativecommons.org/publicdomain/zero/1.0"
     }
   ],
-  "descriptions": [{
-    "description": "These files provide the original survey data of the paper on motivations for biodiversity conservation in Europe. This paper analyses the possibility of building a mutually supportive dynamics between\n      internally and<br> externally motivated behaviour for biodiversity conservation and ecosystem services provision. To this<br> purpose a face to face survey amongst 169 key actors of 34 highly successful and prominent\n      biodiversity<br> arrangements in seven EU countries was conducted. The main<br> finding of the paper is the feasibility of<br> combining inherently intrinsically motivated behaviours (providing enjoyment, pleasure from<br> experimentation and learning, aesthetic satisfaction) and internalized extrinsic motivations (related<br> to the identification with the collective goals of conservation policy) through a common set of governance<br> features.\n      Successful initiatives that combine internal and external motivations share the following<br> features: inclusive decision making processes, a broad monitoring by “peers” beyond the core staff of the<br>\n      initiatives, and a context that is supportive for the building of autonomous actor competences. These<br> findings are in line with the psycho-sociological theory of motivation, which shows the importance of a<br> psycho-social\n      context leading to a subjective perception of autonomy and a sense of competence of the<br> actors.",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [
-
+  "descriptions": [
+    {
+      "description": "These files provide the original survey data of the paper on motivations for biodiversity conservation in Europe. This paper analyses the possibility of building a mutually supportive dynamics between\n      internally and<br> externally motivated behaviour for biodiversity conservation and ecosystem services provision. To this<br> purpose a face to face survey amongst 169 key actors of 34 highly successful and prominent\n      biodiversity<br> arrangements in seven EU countries was conducted. The main<br> finding of the paper is the feasibility of<br> combining inherently intrinsically motivated behaviours (providing enjoyment, pleasure from<br> experimentation and learning, aesthetic satisfaction) and internalized extrinsic motivations (related<br> to the identification with the collective goals of conservation policy) through a common set of governance<br> features.\n      Successful initiatives that combine internal and external motivations share the following<br> features: inclusive decision making processes, a broad monitoring by “peers” beyond the core staff of the<br>\n      initiatives, and a context that is supportive for the building of autonomous actor competences. These<br> findings are in line with the psycho-sociological theory of motivation, which shows the importance of a<br> psycho-social\n      context leading to a subjective perception of autonomy and a sense of competence of the<br> actors.",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
   ],
-  "fundingReferences": [{
+  "geoLocations": [],
+  "fundingReferences": [
+    {
       "funderName": "European Commission",
       "funderIdentifier": "https://doi.org/10.13039/501100000780",
       "funderIdentifierType": "Crossref Funder ID",
@@ -95,7 +104,8 @@
       "awardTitle": "Institutionalizing global genetic-resource commons. Global Strategies for accessing and using essential public knowledge assets in the life sciences"
     }
   ],
-  "relatedIdentifiers": [{
+  "relatedIdentifiers": [
+    {
       "relatedIdentifier": "https://zenodo.org/record/47394/files/Data_All_Internal_motivations.pdf",
       "relatedIdentifierType": "URL",
       "relationType": "HasPart"

--- a/tests/data/4.2/datacite-example-polygon-v4.json
+++ b/tests/data/4.2/datacite-example-polygon-v4.json
@@ -9,259 +9,256 @@
     "bibtex": "misc",
     "ris": "DATA"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Den Heijer, C",
-    "givenName": "C",
-    "familyName": "Den Heijer"
-  }],
-  "titles": [{
-    "title": "Meteo measurements at the Sand Motor",
-    "lang": "en"
-  }],
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Den Heijer, C",
+      "givenName": "C",
+      "familyName": "Den Heijer"
+    }
+  ],
+  "titles": [
+    {
+      "title": "Meteo measurements at the Sand Motor",
+      "lang": "en"
+    }
+  ],
   "publisher": "4TU.Centre for Research Data",
   "container": {},
-  "subjects": [
-
+  "subjects": [],
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2017",
+      "dateType": "Issued"
+    }
   ],
-  "contributors": [
-
-  ],
-  "dates": [{
-    "date": "2017",
-    "dateType": "Issued"
-  }],
   "publicationYear": "2017",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/example-polygon"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/example-polygon"
+    }
   ],
+  "sizes": [],
   "formats": [
     "application/x-netcdf"
   ],
-  "rightsList": [
-
+  "rightsList": [],
+  "descriptions": [],
+  "geoLocations": [
+    {
+      "geoLocationPolygon": [
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.1738852605822",
+            "pointLatitude": "52.03913926329928"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.177180694215117",
+            "pointLatitude": "52.04164225918711"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.180535246850687",
+            "pointLatitude": "52.04399625464452"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.184849833488133",
+            "pointLatitude": "52.04692936720903"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.188676339698225",
+            "pointLatitude": "52.04967415251541"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.191534369184121",
+            "pointLatitude": "52.05170714064434"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.194175770686163",
+            "pointLatitude": "52.05334245636797"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.195777670597483",
+            "pointLatitude": "52.05421289062893"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.197318856770764",
+            "pointLatitude": "52.05560708986616"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.197244535290235",
+            "pointLatitude": "52.05647414552436"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.194878372206108",
+            "pointLatitude": "52.05558026532434"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.192275513207293",
+            "pointLatitude": "52.0540037664795"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.190139539757181",
+            "pointLatitude": "52.05338309097328"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.188563539343029",
+            "pointLatitude": "52.05409113125509"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.188843259016792",
+            "pointLatitude": "52.05555708237333"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.190440325374933",
+            "pointLatitude": "52.05648630398393"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.193486805620985",
+            "pointLatitude": "52.05721863750948"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.195782715369962",
+            "pointLatitude": "52.05905125521555"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.196042562042681",
+            "pointLatitude": "52.0603024859894"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.194522303279684",
+            "pointLatitude": "52.06042019458354"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.191569341305619",
+            "pointLatitude": "52.05985079275935"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.188970128279688",
+            "pointLatitude": "52.05933203100292"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.185846614849885",
+            "pointLatitude": "52.05849919443985"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.183766834165052",
+            "pointLatitude": "52.05768273662148"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.182190558076597",
+            "pointLatitude": "52.05665770545129"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.180730516454513",
+            "pointLatitude": "52.05512223937299"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.179642892536666",
+            "pointLatitude": "52.05335222714644"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.178442502618839",
+            "pointLatitude": "52.05152018985662"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.1774713992764",
+            "pointLatitude": "52.04954999812316"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.176346178024046",
+            "pointLatitude": "52.04728138670279"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.175182683314049",
+            "pointLatitude": "52.04497104660534"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.173373650824841",
+            "pointLatitude": "52.04226286332442"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.173204764844041",
+            "pointLatitude": "52.04016615926179"
+          }
+        },
+        {
+          "polygonPoint": {
+            "pointLongitude": "4.1738852605822",
+            "pointLatitude": "52.03913926329928"
+          }
+        }
+      ],
+      "geoLocationPlace": "Zandmotor, sand suppletion area on the Dutch coast."
+    }
   ],
-  "descriptions": [
-
-  ],
-  "geoLocations": [{
-    "geoLocationPolygon": [{
-        "polygonPoint": {
-          "pointLongitude": "4.1738852605822",
-          "pointLatitude": "52.03913926329928"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.177180694215117",
-          "pointLatitude": "52.04164225918711"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.180535246850687",
-          "pointLatitude": "52.04399625464452"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.184849833488133",
-          "pointLatitude": "52.04692936720903"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.188676339698225",
-          "pointLatitude": "52.04967415251541"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.191534369184121",
-          "pointLatitude": "52.05170714064434"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.194175770686163",
-          "pointLatitude": "52.05334245636797"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.195777670597483",
-          "pointLatitude": "52.05421289062893"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.197318856770764",
-          "pointLatitude": "52.05560708986616"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.197244535290235",
-          "pointLatitude": "52.05647414552436"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.194878372206108",
-          "pointLatitude": "52.05558026532434"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.192275513207293",
-          "pointLatitude": "52.0540037664795"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.190139539757181",
-          "pointLatitude": "52.05338309097328"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.188563539343029",
-          "pointLatitude": "52.05409113125509"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.188843259016792",
-          "pointLatitude": "52.05555708237333"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.190440325374933",
-          "pointLatitude": "52.05648630398393"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.193486805620985",
-          "pointLatitude": "52.05721863750948"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.195782715369962",
-          "pointLatitude": "52.05905125521555"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.196042562042681",
-          "pointLatitude": "52.0603024859894"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.194522303279684",
-          "pointLatitude": "52.06042019458354"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.191569341305619",
-          "pointLatitude": "52.05985079275935"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.188970128279688",
-          "pointLatitude": "52.05933203100292"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.185846614849885",
-          "pointLatitude": "52.05849919443985"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.183766834165052",
-          "pointLatitude": "52.05768273662148"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.182190558076597",
-          "pointLatitude": "52.05665770545129"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.180730516454513",
-          "pointLatitude": "52.05512223937299"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.179642892536666",
-          "pointLatitude": "52.05335222714644"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.178442502618839",
-          "pointLatitude": "52.05152018985662"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.1774713992764",
-          "pointLatitude": "52.04954999812316"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.176346178024046",
-          "pointLatitude": "52.04728138670279"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.175182683314049",
-          "pointLatitude": "52.04497104660534"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.173373650824841",
-          "pointLatitude": "52.04226286332442"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.173204764844041",
-          "pointLatitude": "52.04016615926179"
-        }
-      },
-      {
-        "polygonPoint": {
-          "pointLongitude": "4.1738852605822",
-          "pointLatitude": "52.03913926329928"
-        }
-      }
-    ],
-    "geoLocationPlace": "Zandmotor, sand suppletion area on the Dutch coast."
-  }],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [
-
-  ],
+  "fundingReferences": [],
+  "relatedIdentifiers": [],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-relationTypeIsIdenticalTo-v4.json
+++ b/tests/data/4.2/datacite-example-relationTypeIsIdenticalTo-v4.json
@@ -9,38 +9,46 @@
     "bibtex": "article",
     "ris": "RPRT"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Kreyenfeld, Michaela",
       "givenName": "Michaela",
       "familyName": "Kreyenfeld",
-      "nameIdentifiers": [{
-        "nameIdentifier": "http://isni.org/isni/0000000117540116",
-        "nameIdentifierScheme": "ISNI"
-      }]
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "http://isni.org/isni/0000000117540116",
+          "nameIdentifierScheme": "ISNI"
+        }
+      ]
     },
     {
       "nameType": "Personal",
       "name": "Hornung, Anne",
       "givenName": "Anne",
       "familyName": "Hornung",
-      "nameIdentifiers": [{
-        "nameIdentifier": "http://viaf.org/viaf/304639093",
-        "nameIdentifierScheme": "VIAF"
-      }]
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "http://viaf.org/viaf/304639093",
+          "nameIdentifierScheme": "VIAF"
+        }
+      ]
     },
     {
       "nameType": "Personal",
       "name": "Kubisch, Karolin",
       "givenName": "Karolin",
       "familyName": "Kubisch",
-      "nameIdentifiers": [{
-        "nameIdentifier": "http://viaf.org/viaf/303937450",
-        "nameIdentifierScheme": "VIAF"
-      }]
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "http://viaf.org/viaf/303937450",
+          "nameIdentifierScheme": "VIAF"
+        }
+      ]
     }
   ],
-  "titles": [{
+  "titles": [
+    {
       "title": "The German Generations and Gender Survey",
       "lang": "en"
     },
@@ -56,7 +64,8 @@
     "title": "Comparative Population Studies Vol 38",
     "firstPage": "No 1 (2013)"
   },
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "Fertility",
       "lang": "en"
     },
@@ -87,34 +96,45 @@
       "lang": "en"
     }
   ],
-  "contributors": [{
-    "nameType": "Organizational",
-    "name": "Federal Institute For Population Research",
-    "contributorType": "ResearchGroup"
-  }],
-  "dates": [{
-    "date": "2013",
-    "dateType": "Issued"
-  }],
+  "contributors": [
+    {
+      "nameType": "Organizational",
+      "name": "Federal Institute For Population Research",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "dates": [
+    {
+      "date": "2013",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2013",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/10.cpos-example"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/10.cpos-example"
+    },
+    {
+      "identifierType": "internal ID",
+      "identifier": "da|ra.14.103"
+    }
   ],
+  "sizes": [],
   "formats": [
     "PDF"
   ],
   "version": "1",
-  "rightsList": [{
-    "rights": "Creative Commons License: Attribution-NonCommercial-NoDerivs 3.0 Unported",
-    "rightsUri": "http://creativecommons.org/licenses/by-nc-nd/3.0/deed",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
+  "rightsList": [
+    {
+      "rights": "Creative Commons License: Attribution-NonCommercial-NoDerivs 3.0 Unported",
+      "rightsUri": "http://creativecommons.org/licenses/by-nc-nd/3.0/deed",
+      "lang": "en-US"
+    }
+  ],
+  "descriptions": [
+    {
       "description": "Comparative Population Studies Vol 38, No 1 (2013)",
       "descriptionType": "SeriesInformation",
       "lang": "en"
@@ -125,13 +145,10 @@
       "lang": "en"
     }
   ],
-  "geoLocations": [
-
-  ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [{
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
       "relatedIdentifier": "urn:nbn:de:bib-cpos-2013-02en8",
       "relatedIdentifierType": "URN",
       "relationType": "IsIdenticalTo"

--- a/tests/data/4.2/datacite-example-software-v4.json
+++ b/tests/data/4.2/datacite-example-software-v4.json
@@ -9,15 +9,18 @@
     "bibtex": "misc",
     "ris": "COMP"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Zielinski, AT",
       "givenName": "AT",
       "familyName": "Zielinski",
-      "nameIdentifiers": [{
-        "nameIdentifier": "https://orcid.org/0000-0002-2997-2175",
-        "nameIdentifierScheme": "ORCID"
-      }]
+      "nameIdentifiers": [
+        {
+          "nameIdentifier": "https://orcid.org/0000-0002-2997-2175",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
     },
     {
       "nameType": "Personal",
@@ -56,13 +59,16 @@
       "familyName": "Popoola"
     }
   ],
-  "titles": [{
-    "title": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\"",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\"",
+      "lang": "en"
+    }
+  ],
   "publisher": "Apollo - University of Cambridge Repository",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "UHRMS"
     },
     {
@@ -81,12 +87,15 @@
       "subject": "Orbitrap"
     }
   ],
-  "contributors": [{
-    "nameType": "Organizational",
-    "name": "Apollo-University Of Cambridge Repository",
-    "contributorType": "ResearchGroup"
-  }],
-  "dates": [{
+  "contributors": [
+    {
+      "nameType": "Organizational",
+      "name": "Apollo-University Of Cambridge Repository",
+      "contributorType": "ResearchGroup"
+    }
+  ],
+  "dates": [
+    {
       "date": "2017-05-08",
       "dateType": "Issued"
     },
@@ -97,23 +106,26 @@
   ],
   "publicationYear": "2017",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/example-software-2.0"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/example-software-2.0"
+    }
   ],
+  "sizes": [],
   "formats": [
     "application/ld+json"
   ],
   "version": "2.0",
-  "rightsList": [{
-    "rights": "GNU General Public License version 3",
-    "rightsUri": "https://opensource.org/licenses/GPL-3.0",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
+  "rightsList": [
+    {
+      "rights": "GNU General Public License version 3",
+      "rightsUri": "https://opensource.org/licenses/GPL-3.0",
+      "lang": "en-US"
+    }
+  ],
+  "descriptions": [
+    {
       "description": "Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper",
       "descriptionType": "Abstract",
       "lang": "en"
@@ -124,13 +136,10 @@
       "lang": "en"
     }
   ],
-  "geoLocations": [
-
-  ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [{
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
       "relatedIdentifier": "doi:10.5072/example-software-1.0",
       "relatedIdentifierType": "DOI",
       "relationType": "IsNewVersionOf"

--- a/tests/data/4.2/datacite-example-video-v4.json
+++ b/tests/data/4.2/datacite-example-video-v4.json
@@ -9,13 +9,16 @@
     "bibtex": "misc",
     "ris": "MPCT"
   },
-  "creators": [{
-    "nameType": "Personal",
-    "name": "Lynn, Briscoe",
-    "givenName": "Briscoe",
-    "familyName": "Lynn"
-  }],
-  "titles": [{
+  "creators": [
+    {
+      "nameType": "Personal",
+      "name": "Lynn, Briscoe",
+      "givenName": "Briscoe",
+      "familyName": "Lynn"
+    }
+  ],
+  "titles": [
+    {
       "title": "Walking Your Space, Evaluating Your Home",
       "lang": "en"
     },
@@ -27,46 +30,42 @@
   ],
   "publisher": "Photovoltaic Institute",
   "container": {},
-  "subjects": [{
-    "subject": "Solar Energy",
-    "lang": "en"
-  }],
-  "contributors": [
-
+  "subjects": [
+    {
+      "subject": "Solar Energy",
+      "lang": "en"
+    }
   ],
-  "dates": [{
-    "date": "2013",
-    "dateType": "Issued"
-  }],
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2013",
+      "dateType": "Issued"
+    }
+  ],
   "publicationYear": "2013",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/1153992"
-  },
-  "sizes": [
-
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/1153992"
+    }
   ],
+  "sizes": [],
   "formats": [
     "MP4"
   ],
-  "rightsList": [
-
+  "rightsList": [],
+  "descriptions": [
+    {
+      "description": "This hour-long video features John Halter as the narrator. Mr. Halter is best known as a journalist rather than a TV star, and here he plays that role as he does an \"expose\" type of walkthrough a new home. The home has been advertised as a house with\n      the very latest in state-of-the art energy efficiency, especially solar. Mr. Halter puts the home through an investigation and determines that it can, indeed, live up to its claims.",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
   ],
-  "descriptions": [{
-    "description": "This hour-long video features John Halter as the narrator. Mr. Halter is best known as a journalist rather than a TV star, and here he plays that role as he does an \"expose\" type of walkthrough a new home. The home has been advertised as a house with\n      the very latest in state-of-the art energy efficiency, especially solar. Mr. Halter puts the home through an investigation and determines that it can, indeed, live up to its claims.",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [
-
-  ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [
-
-  ],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "DataCite",
   "state": "findable"

--- a/tests/data/4.2/datacite-example-workflow-v4.json
+++ b/tests/data/4.2/datacite-example-workflow-v4.json
@@ -9,7 +9,8 @@
     "bibtex": "misc",
     "ris": "GEN"
   },
-  "creators": [{
+  "creators": [
+    {
       "nameType": "Personal",
       "name": "Luo, R",
       "givenName": "R",
@@ -34,13 +35,16 @@
       "familyName": "Li"
     }
   ],
-  "titles": [{
-    "title": "Software and supporting material for \"SOAPdenovo2: An empirically improved memory-efficient short read de novo assembly\"",
-    "lang": "en"
-  }],
+  "titles": [
+    {
+      "title": "Software and supporting material for \"SOAPdenovo2: An empirically improved memory-efficient short read de novo assembly\"",
+      "lang": "en"
+    }
+  ],
   "publisher": "GigaScience Database",
   "container": {},
-  "subjects": [{
+  "subjects": [
+    {
       "subject": "DNA (Genetics)",
       "lang": "en"
     },
@@ -49,10 +53,9 @@
       "lang": "en"
     }
   ],
-  "contributors": [
-
-  ],
-  "dates": [{
+  "contributors": [],
+  "dates": [
+    {
       "date": "2012-12-13",
       "dateType": "Available"
     },
@@ -63,32 +66,33 @@
   ],
   "publicationYear": "2012",
   "language": "en",
-  "identifier": {
-    "identifierType": "DOI",
-    "identifier": "10.5072/100044"
-  },
+  "identifiers": [
+    {
+      "identifierType": "DOI",
+      "identifier": "10.5072/100044"
+    }
+  ],
   "sizes": [
     "31 MB"
   ],
-  "formats": [
-
+  "formats": [],
+  "rightsList": [
+    {
+      "rightsUri": "http://creativecommons.org/publicdomain/zero/1.0",
+      "lang": "en-US"
+    }
   ],
-  "rightsList": [{
-    "rightsUri": "http://creativecommons.org/publicdomain/zero/1.0",
-    "lang": "en-US"
-  }],
-  "descriptions": [{
-    "description": "SOAPdenovo2 is the latest de novo genome assembly package from BGI's SOAP (short oligonucleotide analysis package) suite of tools (homepage here: http://soap.genomics.org.cn/). Compared to SOAPdenovo1, this new version has the advantage of a new\n      algorithm design that reduces memory consumption in graph construction, resolves more repeat regions in contig assembly, increases coverage and length in scaffold construction, improves gap closure, and is optimized for large genomes. Using new\n      sequencing data from the YH (Homo sapiens) diploid genome - the first sequenced Han Chinese individual, an updated assembly was produced (see dataset here: doi:10.5524/100038), with the N50 scores for the contig and scaffold being 3-fold and 50-fold\n      longer, respectively, than the first published version. The genome coverage increased from 81.16% to 93.91%, and memory consumption was ~2/3 times lower during the point of largest memory consumption. Benchmarking with Assemblathon1 and GAGE datasets\n      shows that SOAPdenovo2 greatly surpasses its predecessor SOAPdenovo1 and is competitive to other assemblers on both assembly length and accuracy. In order to facilitate readers to repeat and recreate these findings, configured packages with the\n      compressed pipelines containing all of the necessary shell scripts and tools are available from the BGI FTP server (ftp://public.genomics.org.cn/BGI/SOAPdenovo2). The latest version of SOAPdenovo2 is available from Sourceforge:\n      http://soapdenovo2.sourceforge.net/ These pipelines will also soon be made available from our data platform as Galaxy workflows: http://galaxy.cbiit.cuhk.edu.hk/",
-    "descriptionType": "Abstract",
-    "lang": "en"
-  }],
-  "geoLocations": [
-
+  "descriptions": [
+    {
+      "description": "SOAPdenovo2 is the latest de novo genome assembly package from BGI's SOAP (short oligonucleotide analysis package) suite of tools (homepage here: http://soap.genomics.org.cn/). Compared to SOAPdenovo1, this new version has the advantage of a new\n      algorithm design that reduces memory consumption in graph construction, resolves more repeat regions in contig assembly, increases coverage and length in scaffold construction, improves gap closure, and is optimized for large genomes. Using new\n      sequencing data from the YH (Homo sapiens) diploid genome - the first sequenced Han Chinese individual, an updated assembly was produced (see dataset here: doi:10.5524/100038), with the N50 scores for the contig and scaffold being 3-fold and 50-fold\n      longer, respectively, than the first published version. The genome coverage increased from 81.16% to 93.91%, and memory consumption was ~2/3 times lower during the point of largest memory consumption. Benchmarking with Assemblathon1 and GAGE datasets\n      shows that SOAPdenovo2 greatly surpasses its predecessor SOAPdenovo1 and is competitive to other assemblers on both assembly length and accuracy. In order to facilitate readers to repeat and recreate these findings, configured packages with the\n      compressed pipelines containing all of the necessary shell scripts and tools are available from the BGI FTP server (ftp://public.genomics.org.cn/BGI/SOAPdenovo2). The latest version of SOAPdenovo2 is available from Sourceforge:\n      http://soapdenovo2.sourceforge.net/ These pipelines will also soon be made available from our data platform as Galaxy workflows: http://galaxy.cbiit.cuhk.edu.hk/",
+      "descriptionType": "Abstract",
+      "lang": "en"
+    }
   ],
-  "fundingReferences": [
-
-  ],
-  "relatedIdentifiers": [{
+  "geoLocations": [],
+  "fundingReferences": [],
+  "relatedIdentifiers": [
+    {
       "relatedIdentifier": "10.5072/2047-217x-1-1",
       "relatedIdentifierType": "DOI",
       "relationType": "IsReferencedBy"

--- a/tests/data/datacite-v4.2-full-example.json
+++ b/tests/data/datacite-v4.2-full-example.json
@@ -3,10 +3,10 @@
     "resourceTypeGeneral": "Software",
     "resourceType": "XML"
   },
-  "identifier": {
+  "identifiers": [{
     "identifierType": "DOI",
     "identifier": "10.5072/example-full"
-  },
+  }],
   "creators": [{
     "nameType": "Personal",
     "name": "Miller, Elizabeth",

--- a/tests/example/full.py
+++ b/tests/example/full.py
@@ -4,10 +4,10 @@ from datacite import DataCiteMDSClient, schema42
 # schema31, schema40 or schema41 instead.
 
 data = {
-    'identifier': {
+    'identifiers': [{
         'identifierType': 'DOI',
         'identifier': '10.1234/foo.bar',
-    },
+    }],
     'creators': [
         {'name': 'Smith, John'},
     ],

--- a/tests/test_schema42.py
+++ b/tests/test_schema42.py
@@ -68,6 +68,7 @@ TEST_JSON_FILES = [
     'data/4.2/datacite-example-GeoLocation-v4.json',
     'data/4.2/datacite-example-relationTypeIsIdenticalTo-v4.json',
     'data/4.2/datacite-example-software-v4.json',
+    'data/4.2/datacite-example-DateRange-v4.json',
     'data/datacite-v4.2-full-example.json',
 ]
 
@@ -110,6 +111,8 @@ FILE_PAIRS = [
      'data/4.2/datacite-example-relationTypeIsIdenticalTo-v4.json'),
     ('data/4.2/datacite-example-software-v4.xml',
      'data/4.2/datacite-example-software-v4.json'),
+    ('data/4.2/datacite-example-DateRange-v4.xml',
+     'data/4.2/datacite-example-DateRange-v4.json'),
     ('data/datacite-v4.2-full-example.xml',
      'data/datacite-v4.2-full-example.json'),
 ]
@@ -135,10 +138,10 @@ def test_json_eq_xml(example_xml_file42, example_json42, xsd42):
 def test_identifier(minimal_json42):
     """Test identifier."""
     data = {
-        'identifier': {
+        'identifiers': [{
             'identifierType': 'DOI',
             'identifier': '10.1234/foo.bar',
-        }
+        }]
     }
     validate_json(minimal_json42, data)
     tree = dump_etree(data)

--- a/tests/test_schema42.py
+++ b/tests/test_schema42.py
@@ -364,27 +364,55 @@ def test_resourcetype(minimal_json42):
     assert elem.text == 'Science Software'
 
 
-def test_alternateidentifiers(minimal_json42):
-    """Test alternate identifiers."""
-    pytest.raises(TypeError, dump_etree, {'alternateIdentifiers': {
+def test_identifiers(minimal_json42):
+    """Test identifiers."""
+    pytest.raises(TypeError, dump_etree, {'identifiers': {
         'invalid': 'data'
     }})
 
-    tree = dump_etree({'alternateIdentifiers': []})
-    assert len(tree.xpath('/resource/alternateIdentifiers')) == 0
-
-    data = {'alternateIdentifiers': [
+    data = {'identifiers': [
         {
-            'alternateIdentifier': '10.1234/foo',
-            'alternateIdentifierType': 'DOI',
+            'identifier': '10.1234/foo',
+            'identifierType': 'DOI'
+        }
+    ]}
+    validate_json(minimal_json42, data)
+    tree = dump_etree(data)
+    elem = dump_etree(data).xpath('/resource/identifier')[0]
+    assert elem.get('identifierType') == 'DOI'
+    assert elem.text == '10.1234/foo'
+
+    data = {'identifiers': [
+        {
+            'identifier': '10.1234/foo',
+            'identifierType': 'DOI',
         },
+        {
+            'identifierType': 'internal ID',
+            'identifier': 'da|ra.14.103'
+        }
     ]}
     validate_json(minimal_json42, data)
 
-    elem = dump_etree(
-        data).xpath('/resource/alternateIdentifiers/alternateIdentifier')[0]
-    assert elem.get('alternateIdentifierType') == 'DOI'
+    elem = dump_etree(data).xpath(
+            '/resource/alternateIdentifiers/alternateIdentifier')[0]
+    assert elem.get('alternateIdentifierType') == 'internal ID'
+    assert elem.text == 'da|ra.14.103'
+    elem = dump_etree(data).xpath('/resource/identifier')[0]
+    assert elem.get('identifierType') == 'DOI'
     assert elem.text == '10.1234/foo'
+
+    data = {'identifiers': [
+        {
+            'identifier': '13682',
+            'identifierType': 'Eprint_ID'}
+        ]}
+
+    xml = tostring(data)
+    elem = dump_etree(data).xpath(
+            '/resource/alternateIdentifiers/alternateIdentifier')[0]
+    assert elem.get('alternateIdentifierType') == 'Eprint_ID'
+    assert elem.text == '13682'
 
 
 def test_relatedidentifiers(minimal_json42):
@@ -672,7 +700,6 @@ FIELD_NAMES = [
     'dates',
     'subjects',
     'contributors',
-    'alternateIdentifiers',
     'relatedIdentifiers',
     'sizes',
     'formats',


### PR DESCRIPTION
Get the latest 4.2 schema updates from DataCite.  I'm still working on the XML<->JSON transform for identifiers.  Both identifier and alternative identifiers in the XML need to get merged into the identifiers field in JSON.  I'll also add a small description on the changes between the 4.1 schema and 4.2 DataCite schema (beyond just the new metadata fields).