### PR TITLE
Add support for new DataCite JSON REST API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,3 +53,15 @@ Running the test suite is as simple as: ::
 
     pip install -e .[all]
     ./run-tests.sh
+
+If you're using zsh, use this pip command instead:
+
+    pip install -e .'[all]'
+
+Some tests require a DataCite Test Account.  
+Set the following environment variables 
+$DATACITE_USER, $DATACITE_PW, $DATACITE_PREFIX 
+with your account information for doi.test.datacite.org and
+run: ::
+
+    ./run-tests-pw.sh

--- a/datacite/__init__.py
+++ b/datacite/__init__.py
@@ -9,11 +9,10 @@
 # more details.
 
 
-"""Python API wrapper for the DataCite Metadata Store API."""
-
-from __future__ import absolute_import, print_function
+"""Python API wrapper for the DataCite API."""
 
 from .client import DataCiteMDSClient
+from .rest_client import DataCiteRESTClient
 from .version import __version__
 
-__all__ = ('DataCiteMDSClient', '__version__')
+__all__ = ('DataCiteMDSClient', 'DataCiteRESTClient', '__version__')

--- a/datacite/client.py
+++ b/datacite/client.py
@@ -10,7 +10,8 @@
 
 """Python API client wrapper for the DataCite Metadata Store API.
 
-API documentation is available on https://support.datacite.org/docs/mds-api-guide.
+API documentation is available at
+https://support.datacite.org/docs/mds-api-guide.
 """
 
 from __future__ import absolute_import, print_function

--- a/datacite/request.py
+++ b/datacite/request.py
@@ -9,12 +9,11 @@
 # under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-"""Module for making requests to the DataCite MDS API."""
-
-from __future__ import absolute_import, print_function
+"""Module for making requests to the DataCite API."""
 
 import ssl
 
+import json
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
@@ -80,6 +79,8 @@ class DataCiteRequest(object):
 
         if method == 'POST':
             kwargs['data'] = body
+        if method == 'PUT':
+            kwargs['data'] = body
         if self.timeout is not None:
             kwargs['timeout'] = self.timeout
 
@@ -89,6 +90,10 @@ class DataCiteRequest(object):
             self.data = res.content
             if not isinstance(body, string_types):
                 self.data = self.data.decode('utf8')
+            try:
+                self.json = json.loads(self.data)
+            except ValueError as e:
+                self.json = None
         except RequestException as e:
             raise HttpError(e)
         except ssl.SSLError as e:
@@ -105,6 +110,13 @@ class DataCiteRequest(object):
         params = params or {}
         headers = headers or {}
         return self.request(url, method="POST", body=body, params=params,
+                            headers=headers)
+
+    def put(self, url, body=None, params=None, headers=None):
+        """Make a PUT request."""
+        params = params or {}
+        headers = headers or {}
+        return self.request(url, method="PUT", body=body, params=params,
                             headers=headers)
 
     def delete(self, url, params=None, headers=None):

--- a/datacite/rest_client.py
+++ b/datacite/rest_client.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DataCite.
+#
+# Copyright (C) 2015 CERN.
+# Copyright (C) 2020 Caltech.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Python API client wrapper for the DataCite Rest API.
+
+API documentation is available at
+https://support.datacite.org/reference/introduction.
+"""
+
+import json
+from idutils import normalize_doi
+
+from .errors import DataCiteError
+from .request import DataCiteRequest
+
+
+class DataCiteRESTClient(object):
+    """DataCite REST API client wrapper."""
+
+    def __init__(self, username=None, password=None, url=None, prefix=None,
+                 test_mode=False, api_ver="2", timeout=None):
+        """Initialize the REST client wrapper.
+
+        :param username: DataCite username.
+        :param password: DataCite password.
+        :param url: DataCite API base URL. Defaults to
+            https://api.datacite.org/.
+        :param test_mode: Set to True to change base url to
+        https://api.test.datacite.prg. Defaults to False.
+        :param prefix: DOI prefix (or CFG_DATACITE_DOI_PREFIX).
+        :param api_ver: DataCite API version. Currently has no effect.
+            Default to 2.
+        :param timeout: Connect and read timeout in seconds. Specify a tuple
+            (connect, read) to specify each timeout individually.
+        """
+        self.username = username
+        self.password = password
+        self.prefix = prefix
+        self.api_ver = api_ver  # Currently not used
+
+        if test_mode:
+            self.api_url = 'https://api.test.datacite.org/'
+        else:
+            self.api_url = url or 'https://api.datacite.org/'
+        if self.api_url[-1] != '/':
+            self.api_url = self.api_url + "/"
+
+        self.timeout = timeout
+
+    def __repr__(self):
+        """Create string representation of object."""
+        return '<DataCiteRESTClient: {0}>'.format(self.username)
+
+    def _request_factory(self):
+        """Create a new Request object."""
+        params = {}
+
+        return DataCiteRequest(
+            base_url=self.api_url,
+            username=self.username,
+            password=self.password,
+            default_params=params,
+            timeout=self.timeout,
+        )
+
+    def doi_get(self, doi):
+        """Get the URL where the resource pointed by the DOI is located.
+
+        :param doi: DOI name of the resource.
+        """
+        r = self._request_factory()
+        r.get("dois/" + doi)
+        if r.code == 200:
+            return r.json['data']['attributes']['url']
+        else:
+            raise DataCiteError.factory(r.code, r.data)
+
+    def check_doi(self, doi):
+        """Check doi structure.
+
+        Check that the doi has a form
+        12.12345/123 with the prefix defined
+        """
+        # If prefix is in doi
+        if '/' in doi:
+            split = doi.split('/')
+            if split[0] != self.prefix:
+                # Provided a DOI with the wrong prefix
+                raise ValueError('DOI prefix provided ' + split[0] +
+                                 ' not prefix in rest client '+self.prefix)
+        else:
+            doi = self.prefix + '/' + doi
+        return normalize_doi(doi)
+
+    def post_doi(self, data):
+        """Post a new JSON payload to DataCite."""
+        headers = {'content-type': 'application/vnd.api+json'}
+        r = self._request_factory()
+        body = {"data": data}
+        r.post("dois", body=json.dumps(body), headers=headers)
+        if r.code == 201:
+            return r.json['data']['id']
+        else:
+            raise DataCiteError.factory(r.code, r.data)
+
+    def put_doi(self, doi, data):
+        """Put a JSON payload to DataCite for an existing DOI."""
+        headers = {'content-type': 'application/vnd.api+json'}
+        r = self._request_factory()
+        body = {"data": data}
+        r.put("dois/" + doi, body=json.dumps(body), headers=headers)
+
+        if r.code == 200:
+            return r.json['data']['attributes']
+        else:
+            raise DataCiteError.factory(r.code, r.data)
+
+    def draft_doi(self, metadata=None, doi=None):
+        """Create a draft doi.
+
+        A draft DOI can be deleted
+
+        If doi is not provided, DataCite
+        will automatically create a DOI with a random,
+        recommended DOI suffix
+
+        :param doi: DOI (e.g. 10.123/456)
+        :return:
+        """
+        data = {"attributes": {}}
+        if metadata:
+            data['attributes'] = metadata
+        data["attributes"]["prefix"] = self.prefix
+        if doi:
+            doi = self.check_doi(doi)
+            data["attributes"]["doi"] = doi
+        return self.post_doi(data)
+
+    def update_url(self, doi, url):
+        """Update the url of a doi.
+
+        :param url: URL where the doi will resolve.
+        :param doi: DOI (e.g. 10.123/456)
+        :return:
+        """
+        doi = self.check_doi(doi)
+        data = {"attributes": {"url": url}}
+
+        result = self.put_doi(doi, data)
+        return result['url']
+
+    def delete_doi(self, doi):
+        """Delete a doi.
+
+        This will only work for draft dois
+
+        :param doi: DOI (e.g. 10.123/456)
+        :return:
+        """
+        r = self._request_factory()
+        r.delete("dois/" + doi)
+
+        if r.code != 204:
+            raise DataCiteError.factory(r.code, r.data)
+
+    def public_doi(self, metadata, url, doi=None):
+        """Create a public doi.
+
+        This DOI will be public and cannot be deleted
+
+        If doi is not provided, DataCite
+        will automatically create a DOI with a random,
+        recommended DOI suffix
+
+        Metadata should follow the DataCite Metadata Schema:
+        http://schema.datacite.org/
+
+        :param metadata: JSON format of the metadata.
+        :param doi: DOI (e.g. 10.123/456)
+        :param url: URL where the doi will resolve.
+        :return:
+        """
+        data = {"attributes": metadata}
+        data["attributes"]["prefix"] = self.prefix
+        data["attributes"]["event"] = "publish"
+        data["attributes"]["url"] = url
+        if doi:
+            doi = self.check_doi(doi)
+            data["attributes"]["doi"] = doi
+
+        return self.post_doi(data)
+
+    def update_doi(self, doi, metadata=None, url=None):
+        """Update the metadata or url for a DOI.
+
+        :param url: URL where the doi will resolve.
+        :param metadata: JSON format of the metadata.
+        :return:
+        """
+        data = {"attributes": {}}
+        doi = self.check_doi(doi)
+        data["attributes"]["doi"] = doi
+        if metadata:
+            data['attributes'] = metadata
+        if url:
+            data["attributes"]["url"] = url
+
+        return self.put_doi(doi, data)
+
+    def private_doi(self, metadata, url, doi=None):
+        """Publish a doi in a registered state.
+
+        A DOI generated by this method will
+        not be found in DataCite Search
+
+        This DOI cannot be deleted
+
+        If doi is not provided, DataCite
+        will automatically create a DOI with a random,
+        recommended DOI suffix
+
+        Metadata should follow the DataCite Metadata Schema:
+        http://schema.datacite.org/
+
+        :param metadata: JSON format of the metadata.
+        :return:
+        """
+        data = {"attributes": metadata}
+        data["attributes"]["prefix"] = self.prefix
+        data["attributes"]["event"] = "register"
+        data["attributes"]["url"] = url
+        if doi:
+            doi = self.check_doi(doi)
+            data["attributes"]["doi"] = doi
+
+        return self.post_doi(data)
+
+    def hide_doi(self, doi):
+        """Hide a previously registered DOI.
+
+        This DOI will no
+        longer be found in DataCite Search
+
+        :param doi: DOI to hide e.g. 10.12345/1.
+        :return:
+        """
+        data = {"attributes": {"event": "hide"}}
+        if doi:
+            doi = self.check_doi(doi)
+            data["attributes"]["doi"] = doi
+
+        return self.put_doi(doi, data)
+
+    def show_doi(self, doi):
+        """Show a previously registered DOI.
+
+        This DOI will be found in DataCite Search
+
+        :param doi: DOI to hide e.g. 10.12345/1.
+        :return:
+        """
+        data = {"attributes": {"event": "publish"}}
+        if doi:
+            doi = self.check_doi(doi)
+            data["attributes"]["doi"] = doi
+
+        return self.put_doi(doi, data)
+
+    def metadata_get(self, doi):
+        """Get the JSON metadata associated to a DOI name.
+
+        :param doi: DOI name of the resource.
+        """
+        """Put a JSON payload to DataCite for an existing DOI."""
+        headers = {'content-type': 'application/vnd.api+json'}
+        r = self._request_factory()
+        r.get("dois/" + doi, headers=headers)
+
+        if r.code == 200:
+            return r.json['data']['attributes']
+        else:
+            raise DataCiteError.factory(r.code, r.data)
+
+    def media_get(self, doi):
+        """Get list of pairs of media type and URLs associated with a DOI.
+
+        :param doi: DOI name of the resource.
+        """
+        headers = {'content-type': 'application/vnd.api+json'}
+        r = self._request_factory()
+        r.get("dois/" + doi, headers=headers)
+
+        if r.code == 200:
+            return r.json['relationships']['media']
+        else:
+            raise DataCiteError.factory(r.code, r.data)

--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -58,8 +58,8 @@ def validate(data):
 
 @rules.rule('identifiers')
 def identifiers(path, values):
-    """Transform identifiers to alternateIdentifiers and identifier."""
-    """
+    """Transform identifiers to alternateIdentifiers and identifier.
+
     We assume there will only be 1 DOI identifier for the record.
     Any other identifiers are alternative identifiers.
     """

--- a/datacite/xmlutils.py
+++ b/datacite/xmlutils.py
@@ -10,7 +10,6 @@
 
 """XML utilities."""
 
-from __future__ import absolute_import, print_function
 
 from collections import OrderedDict
 from lxml import etree

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,7 @@
 
 """Sphinx configuration."""
 
-from __future__ import print_function
-
 import os
-
 import sphinx.environment
 from docutils.utils import get_source_line
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@
 addopts = --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=datacite --cov-report=term-missing
 testpaths = tests datacite
 norecursedirs = tests/example
+markers = pw: tests that require a password (will only run with '--runpw' option)

--- a/run-tests-pw.sh
+++ b/run-tests-pw.sh
@@ -1,0 +1,20 @@
+# This file is part of DataCite.
+#
+# Copyright (C) 2015, 2016 CERN.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+
+# Quit on errors
+set -o errexit
+
+# Quit on unbound symbols
+set -o nounset
+
+python -m check_manifest --ignore ".*-requirements.txt"
+python -m sphinx.cmd.build -qnNW docs docs/_build/html
+python -m pytest --runpw
+python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
+

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ install_requires = [
     'jsonschema>=3.0.0',
     'lxml>=4.5.0',
     'requests>=2.5.0',
+    'idutils>=1.0.0'
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,30 @@
 
 """Pytest configuration."""
 
-from __future__ import absolute_import, print_function
-
 import json
 import pytest
 import responses
 from lxml import etree
 from os.path import dirname, join
+
+
+def pytest_addoption(parser):
+    """Add option to run tests that require password."""
+    parser.addoption(
+        "--runpw", action="store_true", default=False,
+        help="run tests that require password"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Set up skipping for pw marked items."""
+    if config.getoption("--runpw"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_pw = pytest.mark.skip(reason="need --runpw option to run")
+    for item in items:
+        if "pw" in item.keywords:
+            item.add_marker(skip_pw)
 
 
 @pytest.fixture

--- a/tests/example/full_rest.py
+++ b/tests/example/full_rest.py
@@ -1,0 +1,68 @@
+import os
+from datacite import DataCiteRESTClient, schema42
+
+# If you want to generate XML for earlier versions, you need to use either the
+# schema31, schema40 or schema41 instead.
+
+data = {
+    'identifiers': [{
+        'identifierType': 'DOI',
+        'identifier': '10.1234/foo.bar',
+    }],
+    'creators': [
+        {'name': 'Smith, John'},
+    ],
+    'titles': [
+        {'title': 'Minimal Test Case', }
+    ],
+    'publisher': 'Invenio Software',
+    'publicationYear': '2015',
+    'types': {
+        'resourceType': 'Dataset',
+        'resourceTypeGeneral': 'Dataset'
+    },
+    'schemaVersion': 'http://datacite.org/schema/kernel-4',
+}
+
+# Validate dictionary
+assert schema42.validate(data)
+
+# Generate DataCite XML from dictionary.
+doc = schema42.tostring(data)
+
+# Initialize the REST client.
+username = os.environ["DATACITE_USER"]
+password = os.environ["DATACITE_PW"]
+prefix = os.environ["DATACITE_PREFIX"]
+d = DataCiteRESTClient(
+    username=username,
+    password=password,
+    prefix=prefix,
+    test_mode=True
+)
+
+# Reserve a draft DOI
+doi = d.draft_doi()
+
+# Mint new DOI
+#d.doi_post('10.5072/test-doi', 'http://example.org/test-doi')
+
+# Get DOI location
+#location = d.doi_get(doi)
+
+# Set alternate URL for content type (available through api)
+#d.media_post(
+#    "10.5072/test-doi",
+#    {"application/json": "http://example.org/test-doi/json/",
+#     "application/xml": "http://example.org/test-doi/xml/"}
+#)
+
+# Get alternate URLs
+#mapping = d.media_get("10.5072/test-doi")
+#assert mapping["application/json"] == "http://example.org/test-doi/json/"
+
+# Get metadata for DOI
+#doc = d.metadata_get("10.5072/test-doi")
+
+# Make DOI inactive
+#d.metadata_delete("10.5072/test-doi")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,9 +17,10 @@ import json
 import os
 from os.path import dirname, join
 
-from datacite import DataCiteMDSClient
+from datacite import DataCiteMDSClient, DataCiteRESTClient
 
 APIURL = "https://mds.example.org/"
+RESTURL = "https://doi.example.org/"
 
 
 def get_client(username="DC", password="pw", prefix='10.5072',
@@ -33,6 +34,27 @@ def get_client(username="DC", password="pw", prefix='10.5072',
         test_mode=test_mode,
         timeout=timeout,
     )
+
+
+def get_rest(username="DC", password="pw", prefix='10.5072',
+             test_mode=False, timeout=None):
+    """Create a REST API client."""
+    return DataCiteRESTClient(
+        username=username,
+        password=password,
+        prefix=prefix,
+        url=RESTURL,
+        test_mode=test_mode,
+        timeout=timeout,
+    )
+
+
+def get_credentials():
+    """Helper method for getting credentials from environment."""
+    username = os.environ["DATACITE_USER"]
+    password = os.environ["DATACITE_PW"]
+    prefix = os.environ["DATACITE_PREFIX"]
+    return username, password, prefix
 
 
 def load_xml_path(path):

--- a/tests/rest_helpers.py
+++ b/tests/rest_helpers.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DataCite.
+#
+# Copyright (C) 2015, 2016 CERN.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Test helpers."""
+
+from __future__ import absolute_import, print_function
+
+from datacite import DataCiteRESTClient
+
+
+def get_rest(username="DC", password="pw",
+             test_mode=True, timeout=None):
+    """Create a API client."""
+    return DataCiteRESTClient(
+        username=username,
+        password=password,
+        test_mode=test_mode,
+        timeout=timeout,
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,8 +10,6 @@
 
 """Test client."""
 
-from __future__ import absolute_import, print_function
-
 import ssl
 
 import pytest

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DataCite.
+#
+# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2020 Caltech.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Tests for REST API."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import responses
+from helpers import RESTURL, TEST_43_JSON_FILES, get_credentials, get_rest, \
+    load_json_path
+
+from datacite.errors import DataCiteForbiddenError, DataCiteGoneError, \
+    DataCiteNoContentError, DataCiteNotFoundError, DataCiteServerError, \
+    DataCiteUnauthorizedError
+
+
+@pytest.mark.pw
+def test_rest_create_draft():
+    username, password, prefix = get_credentials()
+    d = get_rest(username=username, password=password,
+                 prefix=prefix, test_mode=True)
+    doi = d.draft_doi()
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+    url = 'https://github.com/inveniosoftware/datacite'
+    new_url = d.update_url(doi, url)
+    assert new_url == url
+    d.delete_doi(doi)
+
+
+@pytest.mark.pw
+def test_rest_create_draft_metadata():
+    username, password, prefix = get_credentials()
+    d = get_rest(username=username, password=password,
+                 prefix=prefix, test_mode=True)
+    metadata = {"titles": [{"title": "hello world", "lang": "en"}]}
+    doi = prefix+'/12345'
+    returned_doi = d.draft_doi(metadata, doi)
+    assert returned_doi == doi
+    url = 'https://github.com/inveniosoftware/datacite'
+    returned_metadata = d.update_doi(doi, url=url)
+    assert returned_metadata['url'] == url
+    assert returned_metadata['titles'][0]['title'] == 'hello world'
+    d.delete_doi(doi)
+
+
+@responses.activate
+def test_rest_create_draft_mock():
+    prefix = '10.1234'
+    mock = 'https://github.com/inveniosoftware/datacite'
+    data = {"data": {"id": prefix+"/1", "attributes": {"url": mock}}}
+    responses.add(
+        responses.POST,
+        "{0}dois".format(RESTURL),
+        json=data,
+        status=201,
+    )
+    # test_mode=False because we already introduced a fake url
+    # with RESTURL variable
+    d = get_rest(username='mock', password='mock',
+                 prefix=prefix)
+    doi = d.draft_doi()
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+
+    responses.add(
+        responses.PUT,
+        "{0}dois/10.1234/1".format(RESTURL),
+        json=data,
+        status=200,
+    )
+    new_url = d.update_url(doi, mock)
+    assert new_url == mock
+
+    responses.add(
+        responses.DELETE,
+        "{0}dois/10.1234/1".format(RESTURL),
+        status=204,
+    )
+    d.delete_doi(doi)
+
+
+@pytest.mark.parametrize('example_json43', TEST_43_JSON_FILES)
+@pytest.mark.pw
+def test_rest_create_public(example_json43):
+    """Test creating DOIs with all example metadata"""
+    example_metadata = load_json_path(example_json43)
+    url = 'https://github.com/inveniosoftware/datacite'
+    username, password, prefix = get_credentials()
+    d = get_rest(username=username, password=password,
+                 prefix=prefix, test_mode=True)
+    doi = d.public_doi(example_metadata, url)
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+    metadata = {'publisher': 'Invenio'}
+    new_metadata = d.update_doi(doi, metadata)
+    assert new_metadata['publisher'] == 'Invenio'
+    url = 'https://github.com/inveniosoftware'
+    new_metadata = d.update_doi(doi, url=url)
+    assert new_metadata['url'] == url
+
+
+@responses.activate
+def test_rest_create_public_mock():
+    """Test creating DOI"""
+    prefix = '10.1234'
+    example_json43 = 'data/datacite-v4.3-full-example.json'
+    example_metadata = load_json_path(example_json43)
+    url = 'https://github.com/inveniosoftware/datacite'
+    data = {"data": {"id": prefix+"/1", "attributes": {"url": url}}}
+    responses.add(
+        responses.POST,
+        "{0}dois".format(RESTURL),
+        json=data,
+        status=201,
+    )
+    # test_mode=False because we already introduced a fake url
+    # with RESTURL variable
+    d = get_rest(username='mock', password='mock',
+                 prefix=prefix)
+    doi = d.public_doi(example_metadata, url)
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+    url = 'https://github.com/inveniosoftware'
+    data = {"data": {"id": prefix+"/1", "attributes":
+            {"publisher": "Invenio", "url": url}}}
+    responses.add(
+        responses.PUT,
+        "{0}dois/{1}/1".format(RESTURL, prefix),
+        json=data,
+        status=200,
+    )
+    metadata = {'publisher': 'Invenio'}
+    new_metadata = d.update_doi(doi, metadata)
+    assert new_metadata['publisher'] == 'Invenio'
+    new_metadata = d.update_doi(doi, url=url)
+    assert new_metadata['url'] == url
+
+
+@pytest.mark.pw
+def test_rest_create_private():
+    """Test creating private DOI"""
+    example_json43 = 'data/4.3/datacite-example-dataset-v4.json'
+    example_metadata = load_json_path(example_json43)
+    url = 'https://github.com/inveniosoftware/datacite'
+    username, password, prefix = get_credentials()
+    d = get_rest(username=username, password=password,
+                 prefix=prefix, test_mode=True)
+    doi = d.private_doi(example_metadata, url)
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+    datacite_metadata = d.metadata_get(doi)
+    assert datacite_metadata['state'] == 'registered'
+    new_metadata = d.show_doi(doi)
+    assert new_metadata['state'] == 'findable'
+    new_metadata = d.hide_doi(doi)
+    assert new_metadata['state'] == 'registered'
+
+
+@responses.activate
+def test_rest_create_private_mock():
+    """Test creating private DOI"""
+    example_json43 = 'data/4.3/datacite-example-dataset-v4.json'
+    example_metadata = load_json_path(example_json43)
+    prefix = '10.1234'
+    url = 'https://github.com/inveniosoftware/datacite'
+    data = {"data": {"id": prefix+"/1", "attributes":
+            {"state": "registered", "url": url}}}
+    responses.add(
+        responses.POST,
+        "{0}dois".format(RESTURL),
+        json=data,
+        status=201,
+    )
+    responses.add(
+        responses.GET,
+        "{0}dois/{1}/1".format(RESTURL, prefix),
+        json=data,
+        status=200,
+    )
+    # test_mode=False because we already introduced a fake url
+    # with RESTURL variable
+    d = get_rest(username='mock', password='mock',
+                 prefix=prefix)
+    doi = d.private_doi(example_metadata, url)
+    datacite_prefix = doi.split('/')[0]
+    assert datacite_prefix == prefix
+    datacite_metadata = d.metadata_get(doi)
+    assert datacite_metadata['state'] == 'registered'
+    data = {"data": {"id": prefix+"/1", "attributes":
+            {"state": "findable", "url": url}}}
+    responses.add(
+        responses.PUT,
+        "{0}dois/{1}/1".format(RESTURL, prefix),
+        json=data,
+        status=200,
+    )
+    new_metadata = d.show_doi(doi)
+    assert new_metadata['state'] == 'findable'
+
+
+@responses.activate
+def test_rest_get_200():
+    """Test."""
+    url = "http://example.org"
+    data = {"data": {"id": "10.1234/1", "attributes": {"url": url}}}
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        json=data,
+        status=200,
+    )
+
+    d = get_rest()
+    assert url == d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_204():
+    """Test 204 error and test_mode setting."""
+    responses.add(
+        responses.GET,
+        "https://api.test.datacite.org/dois/10.1234/1".format(RESTURL),
+        body="No Content",
+        status=204,
+    )
+
+    d = get_rest(test_mode=True)
+    with pytest.raises(DataCiteNoContentError):
+        d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_401():
+    """Test."""
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        body="Unauthorized",
+        status=401,
+    )
+
+    d = get_rest()
+    with pytest.raises(DataCiteUnauthorizedError):
+        d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_403():
+    """Test."""
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        body="Forbidden",
+        status=403,
+    )
+
+    d = get_rest()
+    with pytest.raises(DataCiteForbiddenError):
+        d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_404():
+    """Test."""
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        body="Not Found",
+        status=404,
+    )
+
+    d = get_rest()
+    with pytest.raises(DataCiteNotFoundError):
+        d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_410():
+    """Test."""
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        body="Gone",
+        status=410,
+    )
+
+    d = get_rest()
+    with pytest.raises(DataCiteGoneError):
+        d.doi_get("10.1234/1")
+
+
+@responses.activate
+def test_doi_get_500():
+    """Test."""
+    responses.add(
+        responses.GET,
+        "{0}dois/10.1234/1".format(RESTURL),
+        body="Internal Server Error",
+        status=500,
+    )
+
+    d = get_rest()
+    with pytest.raises(DataCiteServerError):
+        d.doi_get("10.1234/1")

--- a/tests/test_schema31.py
+++ b/tests/test_schema31.py
@@ -10,8 +10,6 @@
 
 """Tests for format transformations."""
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import pytest
 import xml.etree.ElementTree as ET
 from lxml import etree

--- a/tests/test_schema40.py
+++ b/tests/test_schema40.py
@@ -10,8 +10,6 @@
 
 """Tests for format transformations."""
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import pytest
 import xml.etree.ElementTree as ET
 from lxml import etree

--- a/tests/test_schema41.py
+++ b/tests/test_schema41.py
@@ -10,8 +10,6 @@
 
 """Tests for format transformations."""
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import pytest
 import xml.etree.ElementTree as ET
 from lxml import etree

--- a/tests/test_schema42.py
+++ b/tests/test_schema42.py
@@ -11,34 +11,14 @@
 
 """Tests for format transformations."""
 
-from __future__ import absolute_import, print_function, unicode_literals
-
-import glob
-import io
-import json
 import pytest
 import xml.etree.ElementTree as ET
+from helpers import load_json_path, load_xml_path
 from lxml import etree
 from os.path import dirname, join
 
 from datacite.schema42 import dump_etree, tostring, validate, validator
 from datacite.xmlutils import etree_to_string
-
-
-def load_xml_path(path):
-    """Helper method for loading an XML example file from a path."""
-    path_base = dirname(__file__)
-    with io.open(join(path_base, path), encoding='utf-8') as file:
-        content = file.read()
-    return content
-
-
-def load_json_path(path):
-    """Helper method for loading a JSON example file from a path."""
-    path_base = dirname(__file__)
-    with io.open(join(path_base, path), encoding='utf-8') as file:
-        content = file.read()
-    return json.loads(content)
 
 
 def validate_json(minimal_json, extra_json):

--- a/tests/test_schema43.py
+++ b/tests/test_schema43.py
@@ -11,8 +11,6 @@
 
 """Tests for format transformations."""
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import pytest
 import xml.etree.ElementTree as ET
 from helpers import TEST_43_JSON_FILES, load_json_path, load_xml_path


### PR DESCRIPTION
DataCite has a new JSON REST API, and this PR will add a new client for interacting with this API.  At a minimum it will handle getting DOI metadata and all DOI minting functionality.  The REST API will eventually replace the existing MDS API.

I've added in some tests that require a DataCite test password; these are marked so travis should still be happy.

I haven't finished building out tests, and there are a few more functions to write before this is ready for review.