### PR TITLE
request: Change password encoding to utf8

### DIFF
--- a/datacite/request.py
+++ b/datacite/request.py
@@ -40,7 +40,7 @@ class DataCiteRequest(object):
         """Initialize request object."""
         self.base_url = base_url
         self.username = username
-        self.password = password
+        self.password = password.encode('utf8')
         self.default_params = default_params or {}
         self.timeout = timeout
 


### PR DESCRIPTION
DataCite supports any utf8 character in their password. However, the requests library encodes passwords as latin1 (https://2.python-requests.org/en/latest/_modules/requests/auth/). This change will encode the password as utf8, which matches how DataCite currently expects the encoding.