### PR TITLE
rest: cast to string client attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version v1.1.1 (released 2021-04-20):
+
+- Fixes DataCiteRESTClient attributes' type. Prefix, username and password
+  are always cast to string.
+
 Version v1.1.0 (released 2021-04-15):
 
 - Adds full support for DataCite Metadata Schema v4.2 and v4.3 XML generation.

--- a/datacite/rest_client.py
+++ b/datacite/rest_client.py
@@ -41,9 +41,9 @@ class DataCiteRESTClient(object):
         :param timeout: Connect and read timeout in seconds. Specify a tuple
             (connect, read) to specify each timeout individually.
         """
-        self.username = username
-        self.password = password
-        self.prefix = prefix
+        self.username = str(username)
+        self.password = str(password)
+        self.prefix = str(prefix)
 
         if test_mode:
             self.api_url = "https://api.test.datacite.org/"

--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -64,8 +64,6 @@ def identifiers(path, values):
     alt = ''
     doi = ''
     for value in values:
-        print(value['identifierType'])
-        print(value['identifierType'] == 'DOI')
         if value['identifierType'] == 'DOI':
             if doi != '':
                 # Don't know what to do with two DOIs

--- a/datacite/version.py
+++ b/datacite/version.py
@@ -20,4 +20,4 @@ from __future__ import absolute_import, print_function
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
The issue arises when the prefix is casted to a floated point by python... e.g.

![image](https://user-images.githubusercontent.com/6756943/115254478-ad6af400-a12d-11eb-9a0e-2c49899bcf8f.png)

Which happens in `check_doi` function:
```
if '/' in doi:
            split = doi.split('/')
            prefix = split[0]
            if prefix != self.prefix:
                # Provided a DOI with the wrong prefix
>               raise ValueError('Wrong DOI {0} prefix provided, it should be '
                                 '{1} as defined in the rest client'
                                 .format(prefix, self.prefix))
E               ValueError: Wrong DOI 10.1234 prefix provided, it should be 10.1234 as defined in the rest client
```

Will need a release... minor?