### PR TITLE
github: make github release with github action

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,7 +19,6 @@ jobs:
 
     steps:
       - name: "GitHub Release"
-        run: |
           echo "done!"
 
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: "GitHub Release"
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -6,7 +6,7 @@
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details
 
-name: Release
+name: GitHub Release
 
 on:
   push:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,7 +19,6 @@ jobs:
 
     steps:
       - name: "GitHub Release"
-          echo "done!"
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details
+
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  Release:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: "GitHub Release"
+        run: |
+          echo "done!"
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -40,3 +40,4 @@ jobs:
           user: __token__
           # The token is provided by the inveniosoftware organization
           password: ${{ secrets.pypi_token }}
+


### PR DESCRIPTION
This GitHub Action makes a release on GitHub when an appropriate tag is detected. It behaves like the existing pypi GitHub Action. Currently the last release in GitHub is v0.2.0, which is confusing. 

We do not need to make a new release after this is merged. I'll probably just manually do a v1.1.1 release in GitHub to clean up the interface, unless there is opposition.