### PR TITLE
Temporarily swap in working readthedocs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ The datacite package is on PyPI so all you need is: ::
 Documentation
 =============
 
-Documentation is readable at http://datacite.readthedocs.io/ or can be
+Documentation is readable at https://datacite-test.readthedocs.io/ or can be
 built using Sphinx: ::
 
     pip install datacite[docs]


### PR DESCRIPTION
This swaps in an updated readthedocs link, until we can figure out why the existing readthedocs link is not updating #65.