### PR TITLE
Add DataCite 4.5 Support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,34 @@
 Changes
 =======
 
+Version v1.2.0 (released 2024-10-17):
+
+- Updates package setup and adds black formatting
+- Adds support for DataCite Metadata Schema v4.5.
+  The version 4.5 jsonschema includes a number of 
+  changes and improvements:
+
+  - Switches to jsonschema 2019-09 and adds more complete validation
+    to catch mistyped elements
+  - Switches publisher from a string to an object. This means
+    you will need to change publisher to be structured like 
+    `"publisher": {"name": "Invenio Software"}` 
+    when you use version 4.5. This change is needed to
+    support the addition of publisher identifiers.
+  - Removes the identifiers field and added doi, prefix, and suffix fields.
+    These fields are clearer, and DataCite appears to be moving away from the
+    combined identifiers field. doi is not a required field since you may or
+    may not have a DOI depending on your workflow.
+  - Adds new relatedItem elements for publication metadata
+  - Switches geolocation point values to numbers. This is to enable 
+    validation and is consistent with GeoJson and InvenioRDM. It is 
+    different from the DataCite REST API which uses strings, and
+    submitted numbers will be turned into strings by DataCite.
+  - Reorganizes geolocationPolygon to how DataCite is currently rendering this
+    metadata
+  - Adds support for the new resourceTypeGeneral and relationType values
+  - General jsonschema organization improvements
+
 Version v1.1.3 (released 2023-03-20):
 
 - Updates dependency versions and adds python 3.9 support

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ it under the terms of the Revised BSD License quoted below.
 
 Copyright (C) 2015-2018 CERN.
 Copyright (C) 2018 Center for Open Science.
-Copyright (C) 2019 Caltech.
+Copyright (C) 2019-2024 Caltech.
 Copyright (C) 2024 Institute of Biotechnology of the Czech Academy of Sciences.
 
 All rights reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,7 @@ it under the terms of the Revised BSD License quoted below.
 Copyright (C) 2015-2018 CERN.
 Copyright (C) 2018 Center for Open Science.
 Copyright (C) 2019 Caltech.
+Copyright (C) 2024 Institute of Biotechnology of the Czech Academy of Sciences.
 
 All rights reserved.
 

--- a/datacite/__init__.py
+++ b/datacite/__init__.py
@@ -14,6 +14,6 @@
 from .client import DataCiteMDSClient
 from .rest_client import DataCiteRESTClient
 
-__version__ = "1.1.4"
+__version__ = "1.2.0"
 
 __all__ = ("DataCiteMDSClient", "DataCiteRESTClient", "__version__")

--- a/datacite/schema45.py
+++ b/datacite/schema45.py
@@ -1,0 +1,557 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DataCite.
+#
+# Copyright (C) 2016 CERN.
+# Copyright (C) 2019 Caltech.
+# Copyright (C) 2024 IBT Czech Academy of Sciences.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""DataCite v4.5 JSON to XML transformations."""
+
+import pkg_resources
+from lxml import etree
+from lxml.builder import E
+
+from .jsonutils import validator_factory
+from .xmlutils import (
+    Rules,
+    dump_etree_helper,
+    etree_to_string,
+    set_elem_attr,
+    set_non_empty_attr,
+)
+
+rules = Rules()
+
+ns = {
+    None: "http://datacite.org/schema/kernel-4",
+    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    "xml": "xml",
+}
+
+root_attribs = {
+    "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation": "http://datacite.org/schema/kernel-4 "
+    "http://schema.datacite.org/meta/kernel-4.5/metadata.xsd",
+}
+
+validator = validator_factory(
+    pkg_resources.resource_filename("datacite", "schemas/datacite-v4.5.json")
+)
+
+
+def dump_etree(data):
+    """Convert JSON dictionary to DataCite v4.5 XML as ElementTree."""
+    return dump_etree_helper(data, rules, ns, root_attribs)
+
+
+def tostring(data, **kwargs):
+    """Convert JSON dictionary to DataCite v4.5 XML as string."""
+    return etree_to_string(dump_etree(data), **kwargs)
+
+
+def validate(data):
+    """Validate DataCite v4.5 JSON dictionary."""
+    return validator.is_valid(data)
+
+
+def affiliation(root, values):
+    """Extract affiliation."""
+    vals = values.get("affiliation", [])
+    for val in vals:
+        if val.get("name"):
+            elem = E.affiliation(val["name"])
+            # affiliationIdentifier metadata as Attributes
+            # (0-1 cardinality, instead of 0-n as list of objects)
+            set_elem_attr(elem, "affiliationIdentifier", val)
+            set_elem_attr(elem, "affiliationIdentifierScheme", val)
+            if val.get("schemeUri"):
+                elem.set("schemeURI", val["schemeUri"])
+            root.append(elem)
+
+
+def familyname(root, value):
+    """Extract family name."""
+    val = value.get("familyName")
+    if val:
+        root.append(E.familyName(val))
+
+
+def givenname(root, value):
+    """Extract family name."""
+    val = value.get("givenName")
+    if val:
+        root.append(E.givenName(val))
+
+
+def person_or_org_name(root, value, xml_tagname, json_tagname):
+    """Extract creator/contributor name and it's 'nameType' attribute."""
+    elem = E(xml_tagname, value[json_tagname])
+    set_elem_attr(elem, "nameType", value)
+    set_non_empty_attr(elem, "{xml}lang", value.get("lang"))
+    root.append(elem)
+
+
+def nameidentifiers(root, values):
+    """Extract nameidentifier."""
+    vals = values.get("nameIdentifiers", [])
+    for val in vals:
+        if val.get("nameIdentifier"):
+            elem = E.nameIdentifier(val["nameIdentifier"])
+            elem.set("nameIdentifierScheme", val["nameIdentifierScheme"])
+            if val.get("schemeUri"):
+                elem.set("schemeURI", val["schemeUri"])
+            root.append(elem)
+
+
+def fetch_creator(root, value):
+    """Extract common values for creator and contributor."""
+    givenname(root, value)
+    familyname(root, value)
+    nameidentifiers(root, value)
+    affiliation(root, value)
+
+
+def title(root, values):
+    """Extract titles."""
+    if not values:
+        return
+
+    for value in values:
+        elem = etree.Element("title", nsmap=ns)
+        elem.text = value["title"]
+        set_non_empty_attr(elem, "{xml}lang", value.get("lang"))
+        # 'type' was a mistake in 4.0 serializer, which is supported
+        # for backwards compatibility until kernel 5 is released.
+        set_non_empty_attr(elem, "titleType", value.get("type"))
+        # 'titleType' will supersede 'type' if available
+        set_non_empty_attr(elem, "titleType", value.get("titleType"))
+        root.append(elem)
+
+
+def related_object(root, value):
+    """Extract attributes of relatedIdentifiers and relatedItems."""
+    if not value:
+        return
+
+    set_elem_attr(root, "relatedMetadataScheme", value)
+    if value.get("schemeUri"):
+        root.set("schemeURI", value["schemeUri"])
+    set_elem_attr(root, "schemeType", value)
+    set_elem_attr(root, "resourceTypeGeneral", value)
+
+
+@rules.rule("alternateIdentifiers")
+def alternate_identifiers(path, values):
+    """Transform to alternateIdentifiers.
+
+    Note that as of version schema 4.5 the identifiers field is deprecated
+    in favour of using alternateIdentifiers and the doi field.
+    """
+    if not values:
+        return
+
+    root = E.alternateIdentifiers()
+    for value in values:
+        elem = E.alternateIdentifier(value["alternateIdentifier"])
+        set_non_empty_attr(
+            elem, "alternateIdentifierType", value.get("alternateIdentifierType")
+        )
+        root.append(elem)
+    return root
+
+
+@rules.rule("creators")
+def creators(path, values):
+    """Transform creators."""
+    if not values:
+        return
+
+    root = E.creators()
+    for value in values:
+        creator = E.creator()
+        person_or_org_name(creator, value, "creatorName", "name")
+        fetch_creator(creator, value)
+        root.append(creator)
+
+    return root
+
+
+@rules.rule("titles")
+def titles(path, values):
+    """Transform titles."""
+    if not values:
+        return
+    root = E.titles()
+    title(root, values)
+    return root
+
+
+@rules.rule("publisher")
+def publisher(path, value):
+    """Transform publisher."""
+    if not value:
+        return
+
+    elem = E.publisher(value.get("name"))
+    set_non_empty_attr(elem, "publisherIdentifier", value.get("publisherIdentifier"))
+    set_non_empty_attr(
+        elem, "publisherIdentifierScheme", value.get("publisherIdentifierScheme")
+    )
+    set_non_empty_attr(elem, "schemeURI", value.get("schemeUri"))
+
+    return elem
+
+
+@rules.rule("publicationYear")
+def publication_year(path, value):
+    """Transform publicationYear."""
+    if not value:
+        return
+    return E.publicationYear(value)
+
+
+@rules.rule("subjects")
+def subjects(path, values):
+    """Transform subjects."""
+    if not values:
+        return
+
+    root = E.subjects()
+    for value in values:
+        elem = E.subject(value["subject"])
+        set_non_empty_attr(elem, "{xml}lang", value.get("lang"))
+        set_elem_attr(elem, "subjectScheme", value)
+        if value.get("schemeUri"):
+            elem.set("schemeURI", value["schemeUri"])
+        if value.get("valueUri"):
+            elem.set("valueURI", value["valueUri"])
+        root.append(elem)
+    return root
+
+
+@rules.rule("contributors")
+def contributors(path, values):
+    """Transform contributors."""
+    if not values:
+        return
+
+    root = E.contributors()
+    for value in values:
+        contributor = E.contributor()
+        person_or_org_name(contributor, value, "contributorName", "name")
+        fetch_creator(contributor, value)
+        set_elem_attr(contributor, "contributorType", value)
+        root.append(contributor)
+
+    return root
+
+
+@rules.rule("dates")
+def dates(path, values):
+    """Transform dates."""
+    if not values:
+        return
+
+    root = E.dates()
+    for value in values:
+        elem = E.date(value["date"], dateType=value["dateType"])
+        set_elem_attr(elem, "dateInformation", value)
+        root.append(elem)
+
+    return root
+
+
+@rules.rule("language")
+def language(path, value):
+    """Transform language."""
+    if not value:
+        return
+    return E.language(value)
+
+
+@rules.rule("types")
+def resource_type(path, value):
+    """Transform resourceType."""
+    elem = E.resourceType()
+    elem.set("resourceTypeGeneral", value["resourceTypeGeneral"])
+    elem.text = value.get("resourceType")
+    return elem
+
+
+@rules.rule("doi")
+def identifier(path, value):
+    """Transform doi into identifier."""
+    if not value:
+        return None
+
+    return E.identifier(value, identifierType="DOI")
+
+
+@rules.rule("relatedIdentifiers")
+def related_identifiers(path, values):
+    """Transform relatedIdentifiers."""
+    if not values:
+        return
+
+    root = E.relatedIdentifiers()
+    for value in values:
+        elem = E.relatedIdentifier()
+        elem.text = value["relatedIdentifier"]
+        elem.set("relationType", value["relationType"])
+        related_object(elem, value)
+        set_elem_attr(elem, "relatedIdentifierType", value)
+        root.append(elem)
+    return root
+
+
+def free_text_list(plural, singular, values):
+    """List of elements with free text."""
+    if not values:
+        return
+    root = etree.Element(plural)
+    for value in values:
+        etree.SubElement(root, singular).text = value
+    return root
+
+
+@rules.rule("sizes")
+def sizes(path, values):
+    """Transform sizes."""
+    return free_text_list("sizes", "size", values)
+
+
+@rules.rule("formats")
+def formats(path, values):
+    """Transform sizes."""
+    return free_text_list("formats", "format", values)
+
+
+@rules.rule("version")
+def version(path, value):
+    """Transform version."""
+    if not value:
+        return
+    return E.version(value)
+
+
+@rules.rule("rightsList")
+def rights(path, values):
+    """Transform rights."""
+    if not values:
+        return
+
+    root = E.rightsList()
+    for value in values:
+        if "rights" in value:
+            elem = E.rights(value["rights"])
+        # Handle the odd case where no rights text present
+        else:
+            elem = E.rights()
+        if value.get("rightsUri"):
+            elem.set("rightsURI", value["rightsUri"])
+        set_elem_attr(elem, "rightsIdentifierScheme", value)
+        set_elem_attr(elem, "rightsIdentifier", value)
+        if value.get("schemeUri"):
+            elem.set("schemeURI", value["schemeUri"])
+        set_non_empty_attr(elem, "{xml}lang", value.get("lang"))
+        root.append(elem)
+    return root
+
+
+@rules.rule("descriptions")
+def descriptions(path, values):
+    """Transform descriptions."""
+    if not values:
+        return
+
+    root = E.descriptions()
+    for value in values:
+        elem = E.description(
+            value["description"], descriptionType=value["descriptionType"]
+        )
+        set_non_empty_attr(elem, "{xml}lang", value.get("lang"))
+        root.append(elem)
+
+    return root
+
+
+def geopoint(root, value):
+    """Extract a point (either geoLocationPoint or polygonPoint)."""
+    root.append(E.pointLongitude(str(value["pointLongitude"])))
+    root.append(E.pointLatitude(str(value["pointLatitude"])))
+
+
+@rules.rule("geoLocations")
+def geolocations(path, values):
+    """Transform geolocations."""
+    if not values:
+        return
+
+    root = E.geoLocations()
+    for value in values:
+        element = E.geoLocation()
+
+        place = value.get("geoLocationPlace")
+        if place:
+            element.append(E.geoLocationPlace(place))
+
+        point = value.get("geoLocationPoint")
+        if point:
+            elem = E.geoLocationPoint()
+            geopoint(elem, point)
+            element.append(elem)
+
+        box = value.get("geoLocationBox")
+        if box:
+            elem = E.geoLocationBox()
+            elem.append(E.westBoundLongitude(str(box["westBoundLongitude"])))
+            elem.append(E.eastBoundLongitude(str(box["eastBoundLongitude"])))
+            elem.append(E.southBoundLatitude(str(box["southBoundLatitude"])))
+            elem.append(E.northBoundLatitude(str(box["northBoundLatitude"])))
+            element.append(elem)
+
+        polygon = value.get("geoLocationPolygon")
+        if polygon:
+            elem = E.geoLocationPolygon()
+            for point in polygon:
+                plainPoint = point.get("polygonPoint")
+                if plainPoint:
+                    e = E.polygonPoint()
+                    geopoint(e, plainPoint)
+                    elem.append(e)
+                inPoint = point.get("inPolygonPoint")
+                if inPoint:
+                    e = E.inPolygonPoint()
+                    geopoint(e, inPoint)
+                    elem.append(e)
+            element.append(elem)
+
+        root.append(element)
+    return root
+
+
+@rules.rule("fundingReferences")
+def fundingreferences(path, values):
+    """Transform funding references."""
+    if not values:
+        return
+
+    root = E.fundingReferences()
+    for value in values:
+        element = E.fundingReference()
+
+        element.append(E.funderName(value.get("funderName")))
+
+        identifier = value.get("funderIdentifier")
+        if identifier:
+            elem = E.funderIdentifier(identifier)
+            typev = value.get("funderIdentifierType")
+            if typev:
+                elem.set("funderIdentifierType", typev)
+            element.append(elem)
+
+        number = value.get("awardNumber")
+        if number:
+            elem = E.awardNumber(number)
+            uri = value.get("awardUri")
+            if uri:
+                elem.set("awardURI", uri)
+            element.append(elem)
+
+        title = value.get("awardTitle")
+        if title:
+            element.append(E.awardTitle(title))
+        if len(element):
+            root.append(element)
+    return root
+
+
+@rules.rule("relatedItems")
+def related_items(path, values):
+    """Transform related items."""
+    if not values:
+        return None
+    pass
+
+    root = E.relatedItems()
+    for value in values:
+        elem = E.relatedItem()
+        set_elem_attr(elem, "relatedItemType", value)
+        set_elem_attr(elem, "relationType", value)
+
+        id_label = "relatedItemIdentifier"
+        if value.get(id_label):
+            related_item_identifier = E.relatedItemIdentifier()
+            re_id = value[id_label]
+            related_item_identifier.text = re_id[id_label]
+            set_elem_attr(related_item_identifier, "relatedItemIdentifierType", re_id)
+            related_object(related_item_identifier, value)
+            elem.append(related_item_identifier)
+
+        creator_values = value.get("creators")
+        if creator_values:
+            re_creators = E.creators()
+            for c in creator_values:
+                creator = E.creator()
+                person_or_org_name(creator, c, "creatorName", "name")
+                fetch_creator(creator, c)
+                re_creators.append(creator)
+            elem.append(re_creators)
+
+        related_titles = E.titles()
+        title(related_titles, value.get("titles"))
+        elem.append(related_titles)
+
+        pub_year = value.get("publicationYear")
+        if pub_year:
+            elem.append(E.publicationYear(pub_year))
+
+        vol = value.get("volume")
+        if vol:
+            elem.append(E.volume(vol))
+
+        issue = value.get("issue")
+        if issue:
+            elem.append(E.issue(issue))
+
+        number = value.get("number")
+        if number:
+            re_number = E.number(number)
+            if value.get("numberType"):
+                set_elem_attr(re_number, "numberType", value)
+            elem.append(re_number)
+
+        first_p = value.get("firstPage")
+        if first_p:
+            elem.append(E.firstPage(first_p))
+
+        last_p = value.get("lastPage")
+        if last_p:
+            elem.append(E.lastPage(last_p))
+
+        pub = value.get("publisher")
+        if pub:
+            elem.append(E.publisher(pub))
+
+        edi = value.get("edition")
+        if edi:
+            elem.append(E.edition(edi))
+
+        contributors_values = value.get("contributors")
+        if contributors_values:
+            re_contributors = E.contributors()
+            for c in contributors_values:
+                contributor = E.contributor()
+                person_or_org_name(contributor, c, "contributorName", "name")
+                fetch_creator(contributor, c)
+                set_elem_attr(contributor, "contributorType", c)
+                re_contributors.append(contributor)
+            elem.append(re_contributors)
+
+        root.append(elem)
+
+    return root

--- a/datacite/schemas/datacite-v4.5.json
+++ b/datacite/schemas/datacite-v4.5.json
@@ -1,0 +1,628 @@
+{
+    "$schema": "http://json-schema.org/2019-09/schema#",
+    "id": "datacite-v4.5.json",
+    "title": "DataCite v4.5",
+    "description": "JSON representation of the DataCite v4.5 schema.",
+    "additionalProperties": false,
+    "definitions": {
+        "nameType": {
+            "type": "string",
+            "enum": [
+                "Organizational",
+                "Personal"
+            ]
+        },
+        "nameIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "nameIdentifier": {"type": "string"},
+                    "nameIdentifierScheme": {"type": "string"},
+                    "schemeUri": {"type": "string", "format": "uri"}
+                },
+                "required": ["nameIdentifier", "nameIdentifierScheme"]
+            },
+            "uniqueItems": true
+        },
+        "affiliation": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {"type": "string"},
+                    "affiliationIdentifier": {"type": "string"},
+                    "affiliationIdentifierScheme": {"type": "string"},
+                    "schemeUri": {"type": "string", "format": "uri"}
+                },
+                "required": ["name"]
+            },
+            "uniqueItems": true
+        },
+        "person": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "nameType": {"$ref": "#/definitions/nameType"},
+                "givenName": {"type": "string"},
+                "familyName": {"type": "string"},
+                "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                "affiliation": {"$ref": "#/definitions/affiliation"},
+                "lang": {"type": "string"}
+            },
+            "required": ["name"]
+        },
+        "creator": {
+            "type": "object",
+            "allOf": [{ "$ref": "#/definitions/person" }],
+            "unevaluatedProperties": false
+        },
+        "contributor": {
+            "type": "object",
+            "allOf": [{ "$ref": "#/definitions/person" }],
+            "unevaluatedProperties": false,
+            "properties": {
+                "contributorType": {"$ref": "#/definitions/contributorType"}
+            },
+            "required": ["name", "contributorType"]
+        },
+        "contributorType": {
+            "type": "string",
+            "enum": [
+                "ContactPerson",
+                "DataCollector",
+                "DataCurator",
+                "DataManager",
+                "Distributor",
+                "Editor",
+                "HostingInstitution",
+                "Producer",
+                "ProjectLeader",
+                "ProjectManager",
+                "ProjectMember",
+                "RegistrationAgency",
+                "RegistrationAuthority",
+                "RelatedPerson",
+                "Researcher",
+                "ResearchGroup",
+                "RightsHolder",
+                "Sponsor",
+                "Supervisor",
+                "WorkPackageLeader",
+                "Other"
+            ]
+        },
+        "titleType": {
+            "type": "string",
+            "enum": [
+                "AlternativeTitle",
+                "Subtitle",
+                "TranslatedTitle",
+                "Other"
+            ]
+        },
+        "longitude": {
+            "type": "number",
+             "maximum": 180,
+             "minimum": -180
+        },
+        "latitude": {
+            "type": "number",
+             "maximum": 90,
+             "minimum": -90
+        },
+        "date": {
+            "type": "string",
+            "anyOf": [
+                {"format": "year"},
+                {"format": "yearmonth"},
+                {"format": "date"},
+                {"format": "datetime"},
+                {"format": "year-range"},
+                {"format": "yearmonth-range"},
+                {"format": "date-range"},
+                {"format": "datetime-range"}
+            ]
+        },
+        "dateType": {
+            "type": "string",
+            "enum": [
+                "Accepted",
+                "Available",
+                "Copyrighted",
+                "Collected",
+                "Created",
+                "Issued",
+                "Submitted",
+                "Updated",
+                "Valid",
+                "Withdrawn",
+                "Other"
+            ]
+        },
+        "resourceTypeGeneral": {
+            "type": "string",
+            "enum": [
+                "Audiovisual",
+                "Book",
+                "BookChapter",
+                "Collection",
+                "ComputationalNotebook",
+                "ConferencePaper",
+                "ConferenceProceeding",
+                "DataPaper",
+                "Dataset",
+                "Dissertation",
+                "Event",
+                "Image",
+                "Instrument",
+                "InteractiveResource",
+                "Journal",
+                "JournalArticle",
+                "Model",
+                "OutputManagementPlan",
+                "PeerReview",
+                "PhysicalObject",
+                "Preprint",
+                "Report",
+                "Service",
+                "Software",
+                "Sound",
+                "Standard",
+                "StudyRegistration",
+                "Text",
+                "Workflow",
+                "Other"
+              ]
+        },
+        "relatedIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ARK",
+                "arXiv",
+                "bibcode",
+                "DOI",
+                "EAN13",
+                "EISSN",
+                "Handle",
+                "IGSN",
+                "ISBN",
+                "ISSN",
+                "ISTC",
+                "LISSN",
+                "LSID",
+                "PMID",
+                "PURL",
+                "UPC",
+                "URL",
+                "URN",
+                "w3id"
+            ]
+        },
+        "relationType": {
+            "type": "string",
+            "enum": [
+                "IsCitedBy",
+                "Cites",
+                "IsCollectedBy",
+                "Collects",
+                "IsSupplementTo",
+                "IsSupplementedBy",
+                "IsContinuedBy",
+                "Continues",
+                "IsDescribedBy",
+                "Describes",
+                "HasMetadata",
+                "IsMetadataFor",
+                "HasVersion",
+                "IsVersionOf",
+                "IsNewVersionOf",
+                "IsPartOf",
+                "IsPreviousVersionOf",
+                "IsPublishedIn",
+                "HasPart",
+                "IsReferencedBy",
+                "References",
+                "IsDocumentedBy",
+                "Documents",
+                "IsCompiledBy",
+                "Compiles",
+                "IsVariantFormOf",
+                "IsOriginalFormOf",
+                "IsIdenticalTo",
+                "IsReviewedBy",
+                "Reviews",
+                "IsDerivedFrom",
+                "IsSourceOf",
+                "IsRequiredBy",
+                "Requires",
+                "IsObsoletedBy",
+                "Obsoletes"
+            ]
+        },
+        "relatedObject": {
+            "type": "object",
+            "properties": {
+                "relationType": {"$ref": "#/definitions/relationType"},
+                "relatedMetadataScheme": {"type": "string"},
+                "schemeUri": {"type": "string", "format": "uri"},
+                "schemeType": {"type": "string"},
+                "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+            },
+            "required": ["relationType"]
+        },
+        "relatedObjectIf": {
+            "properties": {
+                "relationType": {"enum": ["HasMetadata", "IsMetadataFor"]}
+            }
+        },
+        "relatedObjectElse": {
+            "$comment": "these properties may only be used with relation types HasMetadata/IsMetadataFor",
+            "properties": {
+                "relatedMetadataScheme": false,
+                "schemeUri": false,
+                "schemeType": false
+            }
+        },
+        "descriptionType": {
+            "type": "string",
+            "enum": [
+                "Abstract",
+                "Methods",
+                "SeriesInformation",
+                "TableOfContents",
+                "TechnicalInfo",
+                "Other"
+            ]
+        },
+        "geoLocationPoint": {
+            "type": "object",
+            "additionalProperties": false,    
+            "properties": {
+                "pointLongitude": {"$ref": "#/definitions/longitude"},
+                "pointLatitude": {"$ref": "#/definitions/latitude"}
+            },
+            "required": ["pointLongitude", "pointLatitude"]
+        },
+        "funderIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ISNI",
+                "GRID",
+                "Crossref Funder ID",
+                "ROR",
+                "Other"
+            ]
+        },
+        "publicationYear": {
+            "type": "string",
+            "pattern": "^[0-9]{4}$"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "doi": {"type": "string", "pattern" : "^10[.][0-9]{4,9}[/][^\\s]+$"},
+        "prefix":{"type": "string", "pattern": "^10[.][0-9]{4,9}$"},
+        "suffix":{"type": "string", "pattern": "^[^\\s]+$"},
+        "event" : {
+            "type": "string",
+            "enum": [
+                "hide",
+                "register",
+                "publish"
+            ]
+        },
+        "url": {"type": "string", "format": "uri"},
+        "types": {
+            "type": "object",
+            "additionalProperties": false,    
+            "properties": {
+                "resourceType": {"type": "string"},
+                "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+            },
+            "required": ["resourceTypeGeneral"]
+        },
+        "creators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "allOf": [{ "$ref": "#/definitions/creator" }],
+                "required": ["name"]
+            },
+            "minItems": 1
+        },
+        "titles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "title": {"type": "string"},
+                    "titleType": {"$ref": "#/definitions/titleType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["title"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "publisher": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {"type":"string"},
+                "publisherIdentifier": {"type":"string"},
+                "publisherIdentifierScheme": {"type":"string"},
+                "schemeUri": {"type":"string", "format": "uri"},
+                "lang": {"type":"string"}
+            },
+            "required": ["name"]
+        },
+        "publicationYear": {"$ref": "#/definitions/publicationYear"},
+        "subjects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "subject": {"type": "string"},
+                    "subjectScheme": {"type": "string"},
+                    "schemeUri": {"type": "string", "format": "uri"},
+                    "valueUri": {"type": "string", "format": "uri"},
+                    "classificationCode": {"type": "string"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["subject"]
+            },
+            "uniqueItems": true
+        },
+        "contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "allOf": [{ "$ref": "#/definitions/contributor" }],
+                "required": ["contributorType", "name"]
+            }
+        },
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "date": {"$ref": "#/definitions/date"},
+                    "dateType": {"$ref": "#/definitions/dateType"},
+                    "dateInformation": {"type": "string"}
+                },
+                "required": ["date", "dateType"]
+            },
+            "uniqueItems": true
+        },
+        "language": {
+            "type": "string",
+            "$comment": "Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes."
+        },
+        "alternateIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "alternateIdentifier": {"type": "string"},
+                    "alternateIdentifierType": {"type": "string"}
+                },
+                "required": ["alternateIdentifier", "alternateIdentifierType"]
+            },
+            "uniqueItems": true
+        },
+        "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "allOf": [{ "$ref": "#/definitions/relatedObject"}],
+                "unevaluatedProperties": false,
+                "properties": {
+                    "relatedIdentifier": {"type": "string"},
+                    "relatedIdentifierType": {"$ref": "#/definitions/relatedIdentifierType"}
+                },
+                "required": ["relatedIdentifier", "relatedIdentifierType", "relationType"],
+                "if": {"$ref": "#/definitions/relatedObjectIf"},
+                "else": {"$ref": "#/definitions/relatedObjectElse"}
+            }
+        },
+        "relatedItems": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "allOf": [{ "$ref": "#/definitions/relatedObject"}],
+                "unevaluatedProperties": false,
+                "properties": {
+                    "relatedItemIdentifier": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "relatedItemIdentifier": {"type": "string"},
+                          "relatedItemIdentifierType": {"$ref": "#/definitions/relatedIdentifierType"}
+                        },
+                        "required": ["relatedItemIdentifier", "relatedItemIdentifierType"]
+                    },
+                    "relatedItemType": {"$ref": "#/definitions/resourceTypeGeneral"},
+                    "creators": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "unevaluatedProperties": false,
+                            "allOf": [{ "$ref": "#/definitions/creator" }],
+                            "required": ["name"]
+                        }
+                    },
+                    "contributors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "unevaluatedProperties": false,
+                            "allOf": [{ "$ref": "#/definitions/contributor" }],
+                            "required": ["contributorType", "name"]
+                        }
+                    },
+                    "titles": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "title": {"type": "string"},
+                                "titleType": {"$ref": "#/definitions/titleType"},
+                                "lang": {"type": "string"}
+                            },
+                            "required": ["title"]
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "publicationYear": {"$ref": "#/definitions/publicationYear"},
+                    "volume": {"type": "string"},
+                    "issue": {"type": "string"},
+                    "firstPage": {"type": "string"},
+                    "lastPage": {"type": "string"},
+                    "edition": {"type": "string"},
+                    "publisher": {"type": "string"},
+                    "number": {"type":"string"},
+                    "numberType": {
+                        "type": "string",
+                        "enum": [
+                            "Article",
+                            "Chapter",
+                            "Report",
+                            "Other"
+                        ]
+                    }
+                },
+                "required": ["titles", "relatedItemType", "relationType"],
+                "if": {"$ref": "#/definitions/relatedObjectIf"},
+                "else": {"$ref": "#/definitions/relatedObjectElse"}
+            },
+            "uniqueItems": true
+        },
+        "sizes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "version": {
+            "type": "string"
+        },
+        "rightsList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "rights": {"type": "string"},
+                    "rightsUri": {"type": "string", "format": "uri"},
+                    "rightsIdentifier": {"type": "string"},
+                    "rightsIdentifierScheme": {"type": "string"},
+                    "schemeUri": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                }
+            },
+            "uniqueItems": true
+        },
+        "descriptions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "description": {"type": "string"},
+                    "descriptionType": {"$ref": "#/definitions/descriptionType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["description", "descriptionType"]
+            },
+            "uniqueItems": true
+        },
+        "geoLocations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "geoLocationPlace": {"type": "string"},
+                    "geoLocationPoint": {"$ref": "#/definitions/geoLocationPoint"},
+                    "geoLocationBox": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "westBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "eastBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "southBoundLatitude": {"$ref": "#/definitions/latitude"},
+                            "northBoundLatitude": {"$ref": "#/definitions/latitude"}
+                        },
+                        "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
+                    },
+                    "geoLocationPolygon": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "polygonPoint": {"$ref": "#/definitions/geoLocationPoint"},
+                                "inPolygonPoint": {"$ref": "#/definitions/geoLocationPoint"}
+                            }
+                        }
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "fundingReferences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "funderName": {"type": "string"},
+                    "funderIdentifier": {"type": "string"},
+                    "funderIdentifierType": {"$ref": "#/definitions/funderIdentifierType"},
+                    "awardNumber": {"type": "string"},
+                    "awardUri": {"type": "string", "format": "uri"},
+                    "awardTitle": {"type": "string"}
+                },
+                "required": ["funderName"]
+            },
+            "uniqueItems": true
+        },
+        "schemaVersion": {
+            "type": "string",
+            "const": "http://datacite.org/schema/kernel-4"
+        },
+        "container": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "title": {"type": "string"},
+                "firstPage": {"type": "string"}
+            }
+        }
+    },
+    "required": [
+        "creators",
+        "titles",
+        "publisher",
+        "publicationYear",
+        "types",
+        "schemaVersion"
+    ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,14 @@ def example_json_file43():
 
 
 @pytest.fixture
+def example_json_file45():
+    """Load DataCite v4.5 full example JSON."""
+    path = dirname(__file__)
+    with open(join(path, "data", "datacite-v4.5-full-example.json")) as file:
+        return file.read()
+
+
+@pytest.fixture
 def example_json(example_json_file):
     """Load the DataCite v3.1 full example into a dict."""
     return json.loads(example_json_file)
@@ -107,6 +115,12 @@ def example_json42(example_json_file42):
 def example_json43(example_json_file43):
     """Load the DataCite v4.3 full example into a dict."""
     return json.loads(example_json_file43)
+
+
+@pytest.fixture
+def example_json45(example_json_file45):
+    """Load the DataCite v4.5 full example into a dict."""
+    return json.loads(example_json_file45)
 
 
 def load_xml(filename):
@@ -148,6 +162,12 @@ def example_xml_file43():
 
 
 @pytest.fixture
+def example_xml_file45():
+    """Load DataCite v4.5 full example XML."""
+    return load_xml("datacite-v4.5-full-example.xml")
+
+
+@pytest.fixture
 def example_xml(example_xml_file):
     """Load DataCite v3.1 full example as an etree."""
     return etree.fromstring(example_xml_file.encode("utf-8"))
@@ -166,15 +186,21 @@ def example_xml41(example_xml_file41):
 
 
 @pytest.fixture
-def example_xml42(example_xml_file41):
+def example_xml42(example_xml_file42):
     """Load DataCite v4.2 full example as an etree."""
     return etree.fromstring(example_xml_file42.encode("utf-8"))
 
 
 @pytest.fixture
-def example_xml43(example_xml_file41):
+def example_xml43(example_xml_file43):
     """Load DataCite v4.3 full example as an etree."""
     return etree.fromstring(example_xml_file43.encode("utf-8"))
+
+
+@pytest.fixture
+def example_xml45(example_xml_file45):
+    """Load DataCite v4.3 full example as an etree."""
+    return etree.fromstring(example_xml_file45.encode("utf-8"))
 
 
 def _load_xsd(xsd_filename):
@@ -220,6 +246,12 @@ def xsd43():
     return _load_xsd("4.3/metadata.xsd")
 
 
+@pytest.fixture(scope="session")
+def xsd45():
+    """Load DataCite v4.5 full example as an etree."""
+    return _load_xsd("4.5/metadata.xsd")
+
+
 @pytest.fixture(scope="function")
 def minimal_json42():
     """Minimal valid JSON for DataCite 4.2."""
@@ -259,4 +291,21 @@ def minimal_json43():
         "publicationYear": "2016",
         "types": {"resourceType": "", "resourceTypeGeneral": "Software"},
         "schemaVersion": "http://datacite.org/schema/kernel-4",
+    }
+
+
+@pytest.fixture(scope="function")
+def minimal_json45():
+    """Minimal valid JSON for DataCite 4.5."""
+    return {
+        "doi": "10.1234/foo.bar",
+        "creators": [
+            {"name": "Nielsen, Lars Holm"},
+        ],
+        "titles": [{"title": "Minimal Test Case"}],
+        "publisher": {"name": "Invenio Software"},
+        "publicationYear": "2016",
+        "types": {"resourceType": "", "resourceTypeGeneral": "Software"},
+        "schemaVersion": "http://datacite.org/schema/kernel-4",
+        "url": "https://www.example.com",
     }

--- a/tests/data/4.5/datacite-example-dataset-v4.json
+++ b/tests/data/4.5/datacite-example-dataset-v4.json
@@ -1,0 +1,202 @@
+{
+  "doi": "10.82433/9184-dy35",
+  "prefix": "10.82433",
+  "suffix": "9184-dy35",
+  "alternateIdentifiers": [],
+  "creators": [
+    {
+      "name": "National Gallery",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/043kfff89",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "External Environmental Data, 2010-2020, National Gallery"
+    }
+  ],
+  "publisher": {
+    "lang": "en",
+    "name": "National Gallery",
+    "schemeUri": "https://ror.org/",
+    "publisherIdentifier": "https://ror.org/043kfff89",
+    "publisherIdentifierScheme": "ROR"
+  },
+  "container": {},
+  "publicationYear": "2022",
+  "subjects": [
+    {
+      "subject": "FOS: Earth and related environmental sciences",
+      "schemeUri": "http://www.oecd.org/science/inno/38235147.pdf",
+      "subjectScheme": "Fields of Science and Technology (FOS)"
+    },
+    {
+      "subject": "temperature",
+      "valueUri": "https://www.wikidata.org/wiki/Q11466",
+      "schemeUri": "https://www.wikidata.org/wiki",
+      "subjectScheme": "Wikidata"
+    },
+    {
+      "subject": "relative humidity",
+      "valueUri": "http://vocab.getty.edu/aat/300192097",
+      "schemeUri": "http://vocab.getty.edu/aat",
+      "subjectScheme": "Art and Architecture Thesaurus"
+    },
+    {
+      "subject": "illuminance",
+      "valueUri": "https://www.wikidata.org/wiki/Q194411",
+      "schemeUri": "https://www.wikidata.org/wiki",
+      "subjectScheme": "Wikidata"
+    },
+    {
+      "subject": "moisture content",
+      "valueUri": "http://vocab.getty.edu/aat/300379432",
+      "schemeUri": "http://vocab.getty.edu/aat",
+      "subjectScheme": "Art and Architecture Thesaurus"
+    },
+    {
+      "subject": "Environmental monitoring",
+      "valueUri": "http://id.worldcat.org/fast/913214",
+      "schemeUri": "http://id.worldcat.org/fast",
+      "subjectScheme": "FAST"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Padfield, Joseph",
+      "nameType": "Personal",
+      "givenName": "Joseph",
+      "familyName": "Padfield",
+      "affiliation": [
+        {
+          "name": "National Gallery",
+          "affiliationIdentifier": "https://ror.org/043kfff89",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "contributorType": "ContactPerson",
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://orcid.org",
+          "nameIdentifier": "https://orcid.org/0000-0002-2572-6428",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
+    },
+    {
+      "name": "Building Facilities Department",
+      "nameType": "Organizational",
+      "affiliation": [
+        {
+          "name": "National Gallery",
+          "affiliationIdentifier": "https://ror.org/043kfff89",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "contributorType": "DataCollector",
+      "nameIdentifiers": []
+    }
+  ],
+  "dates": [
+    {
+      "date": "2010/2020",
+      "dateType": "Collected"
+    },
+    {
+      "date": "2010/2020",
+      "dateType": "Other",
+      "dateInformation": "Coverage"
+    },
+    {
+      "date": "2022",
+      "dateType": "Issued"
+    }
+  ],
+  "language": "en",
+  "types": {
+    "resourceType": "Environmental data",
+    "resourceTypeGeneral": "Dataset"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsSupplementTo",
+      "relatedIdentifier": "https://www.nationalgallery.org.uk/research/research-resources/research-papers/improving-our-environment",
+      "resourceTypeGeneral": "Report",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relationType": "IsSourceOf",
+      "relatedIdentifier": "https://research.ng-london.org.uk/scientific/env/",
+      "resourceTypeGeneral": "InteractiveResource",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relationType": "IsSupplementedBy",
+      "relatedIdentifier": "10.1080/00393630.2018.1504449/",
+      "resourceTypeGeneral": "JournalArticle",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsDocumentedBy",
+      "relatedIdentifier": "10.5281/zenodo.7629200",
+      "resourceTypeGeneral": "ConferencePaper",
+      "relatedIdentifierType": "DOI"
+    }
+  ],
+  "relatedItems": [],
+  "sizes": [
+    "13.6 MB"
+  ],
+  "formats": [
+    "application/json"
+  ],
+  "version": "1.0",
+  "rightsList": [
+    {
+      "lang": "en",
+      "rights": "Creative Commons Attribution 4.0 International",
+      "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
+      "schemeUri": "https://spdx.org/licenses/",
+      "rightsIdentifier": "cc-by-4.0",
+      "rightsIdentifierScheme": "SPDX"
+    }
+  ],
+  "descriptions": [
+    {
+      "lang": "en",
+      "description": "The National Gallery houses one of the greatest ‒ and most visited ‒ collections of Western European painting, often welcoming more than 6 million visitors a year. The Scientific Department researches the history of materials and techniques and their degradation mechanisms (fading, darkening, etc.), through analysis using a range of micro-analytical and imaging methods. It also works in the fields of preventive conservation and environmental management of galleries (monitoring, lighting, vibration), as well as the development of a wide range of new instruments and methods (both analytical and imaging) for technical examination of artworks, most often in collaboration with universities. The examination of the environmental conditions within The National Gallery began soon after it was established in 1824. Early concerns often related to dust and pollution. The first electronic data logger, recording light levels, was introduced in 1975, with the regular logging of temperature and relative humidity followed soon after. Today the Gallery has hundreds of sensors, monitoring the environmental conditions in over hundreds of locations, 24/7. The National Gallery currently archives millions of environmental readings every year, which are used to monitor the Gallery conditions ensuring the on-going care of the collections. These readings are also used to examine long term environmental trends, manage additional events, and within the planning and management of preventive conservation work and research at the National Gallery. The National Gallery Environmental Database is an internal, bespoke system which has been developed, over the last 20 years, to act as an archive for all of these environmental readings. This dataset contains a selected range of the data gathered from a few of the external sensors that have been used to monitor ambient light levels, temperature, relative humidity and air moisture content 24 hours a day, 7 days a week over the last two decades.",
+      "descriptionType": "Abstract"
+    }
+  ],
+  "geoLocations": [
+    {
+      "geoLocationPlace": "Roof of National Gallery, London, UK",
+      "geoLocationPoint": {
+        "pointLatitude": 51.50872,
+        "pointLongitude": -0.12841
+      }
+    }
+  ],
+  "fundingReferences": [
+    {
+      "awardUri": "https://cordis.europa.eu/project/id/871034",
+      "awardTitle": "Integrating Platforms for the European Research Infrastructure ON Heritage Science",
+      "funderName": "H2020 Excellent Science",
+      "awardNumber": "871034",
+      "funderIdentifier": "https://doi.org/10.13039/100010662",
+      "funderIdentifierType": "Crossref Funder ID"
+    }
+  ],
+  "url": "https://research.ng-london.org.uk/scientific/env/External%20Environmental%20Data%202010-2020%20National%20Gallery%20V1.0.json",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}
+
+

--- a/tests/data/4.5/datacite-example-dataset-v4.xml
+++ b/tests/data/4.5/datacite-example-dataset-v4.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example: Dataset -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/9184-DY35</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Organizational">National Gallery</creatorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/043kfff89</nameIdentifier>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">External Environmental Data, 2010-2020, National Gallery</title>
+  </titles>
+  <publisher xml:lang="en" publisherIdentifier="https://ror.org/043kfff89" publisherIdentifierScheme="ROR" schemeURI="https://ror.org/">National Gallery</publisher>
+  <publicationYear>2022</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset">Environmental data</resourceType>
+  <subjects>
+    <subject subjectScheme="Fields of Science and Technology (FOS)" schemeURI="http://www.oecd.org/science/inno/38235147.pdf">FOS: Earth and related environmental sciences</subject>
+    <subject subjectScheme="Wikidata" schemeURI="https://www.wikidata.org/wiki" valueURI="https://www.wikidata.org/wiki/Q11466">temperature</subject>
+    <subject subjectScheme="Art and Architecture Thesaurus" schemeURI="http://vocab.getty.edu/aat" valueURI="http://vocab.getty.edu/aat/300192097">relative humidity</subject>
+    <subject subjectScheme="Wikidata" schemeURI="https://www.wikidata.org/wiki" valueURI="https://www.wikidata.org/wiki/Q194411">illuminance</subject>
+    <subject subjectScheme="Art and Architecture Thesaurus" schemeURI="http://vocab.getty.edu/aat" valueURI="http://vocab.getty.edu/aat/300379432">moisture content</subject>
+    <subject subjectScheme="FAST" schemeURI="http://id.worldcat.org/fast" valueURI="http://id.worldcat.org/fast/913214">Environmental monitoring</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="ContactPerson">
+      <contributorName nameType="Personal">Padfield, Joseph</contributorName>
+      <givenName>Joseph</givenName>
+      <familyName>Padfield</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0002-2572-6428</nameIdentifier>
+      <affiliation affiliationIdentifier="https://ror.org/043kfff89" affiliationIdentifierScheme="ROR">National Gallery</affiliation>
+    </contributor>
+    <contributor contributorType="DataCollector">
+      <contributorName nameType="Organizational">Building Facilities Department</contributorName>
+      <affiliation affiliationIdentifier="https://ror.org/043kfff89" affiliationIdentifierScheme="ROR">National Gallery</affiliation>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Collected">2010/2020</date>
+    <date dateType="Other" dateInformation="Coverage">2010/2020</date>
+    <date dateType="Issued">2022</date>
+  </dates>
+  <language>en</language>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementTo" resourceTypeGeneral="Report">https://www.nationalgallery.org.uk/research/research-resources/research-papers/improving-our-environment</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsSourceOf" resourceTypeGeneral="InteractiveResource">https://research.ng-london.org.uk/scientific/env/</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="JournalArticle">10.1080/00393630.2018.1504449/</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsDocumentedBy" resourceTypeGeneral="ConferencePaper">10.5281/zenodo.7629200</relatedIdentifier>
+  </relatedIdentifiers>
+  <sizes>
+    <size>13.6 MB</size>
+  </sizes>
+  <formats>
+    <format>application/json</format>
+  </formats>
+  <version>1.0</version>
+  <rightsList>
+    <rights xml:lang="en" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC-BY-4.0" rightsURI="https://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution Non Commercial 4.0 International</rights>
+  </rightsList>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">The National Gallery houses one of the greatest ‒ and most visited ‒ collections of Western European painting, often welcoming more than 6 million visitors a year. The Scientific Department researches the history of materials and techniques and their degradation mechanisms (fading, darkening, etc.), through analysis using a range of micro-analytical and imaging methods. It also works in the fields of preventive conservation and environmental management of galleries (monitoring, lighting, vibration), as well as the development of a wide range of new instruments and methods (both analytical and imaging) for technical examination of artworks, most often in collaboration with universities. The examination of the environmental conditions within The National Gallery began soon after it was established in 1824. Early concerns often related to dust and pollution. The first electronic data logger, recording light levels, was introduced in 1975, with the regular logging of temperature and relative humidity followed soon after. Today the Gallery has hundreds of sensors, monitoring the environmental conditions in over hundreds of locations, 24/7. The National Gallery currently archives millions of environmental readings every year, which are used to monitor the Gallery conditions ensuring the on-going care of the collections. These readings are also used to examine long term environmental trends, manage additional events, and within the planning and management of preventive conservation work and research at the National Gallery. The National Gallery Environmental Database is an internal, bespoke system which has been developed, over the last 20 years, to act as an archive for all of these environmental readings. This dataset contains a selected range of the data gathered from a few of the external sensors that have been used to monitor ambient light levels, temperature, relative humidity and air moisture content 24 hours a day, 7 days a week over the last two decades.</description>
+  </descriptions>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPlace>Roof of National Gallery, London, UK</geoLocationPlace>
+      <geoLocationPoint>
+        <pointLatitude>51.50872</pointLatitude>
+        <pointLongitude>-0.12841</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>H2020 Excellent Science</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/100010662</funderIdentifier>
+      <awardNumber awardURI="https://cordis.europa.eu/project/id/871034">871034</awardNumber>
+      <awardTitle>Integrating Platforms for the European Research Infrastructure ON Heritage Science</awardTitle>
+    </fundingReference>
+  </fundingReferences>
+</resource>

--- a/tests/data/4.5/datacite-example-instrument-v4.json
+++ b/tests/data/4.5/datacite-example-instrument-v4.json
@@ -1,0 +1,99 @@
+{
+  "doi": "10.82433/08qf-ee96",
+  "prefix": "10.82433",
+  "suffix": "08qf-ee96",
+  "alternateIdentifiers": [
+    {
+      "alternateIdentifierType": "SerialNumber",
+      "alternateIdentifier": "1234567"
+    }
+  ],
+  "creators": [
+    {
+      "name": "DECTRIS",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://www.wikidata.org/wiki/",
+          "nameIdentifier": "Q107529885",
+          "nameIdentifierScheme": "Wikidata"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en-US",
+      "title": "Pilatus detector at MX station 14.1"
+    }
+  ],
+  "publisher": {
+    "lang": "en",
+    "name": "Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences"
+  },
+  "container": {
+    "type": "Series",
+    "identifier": "1234.1675",
+    "identifierType": "Handle"
+  },
+  "publicationYear": "2022",
+  "subjects": [],
+  "contributors": [
+    {
+      "name": "Helmholtz-Zentrum Berlin Für Materialien Und Energie",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "HostingInstitution",
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/02aj13c28",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    }
+  ],
+  "dates": [
+    {
+      "date": "2022",
+      "dateType": "Issued"
+    }
+  ],
+  "types": {
+    "resourceType": "Raster image pixel detector",
+    "resourceTypeGeneral": "Instrument"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsPartOf",
+      "relatedIdentifier": "1234.1675",
+      "resourceTypeGeneral": "Instrument",
+      "relatedIdentifierType": "Handle"
+    },
+    {
+      "relationType": "IsDescribedBy",
+      "relatedIdentifier": "https://www.dectris.com/products/pilatus3/pilatus3-s-for-synchrotron/details/pilatus3-s-6m",
+      "resourceTypeGeneral": "Text",
+      "relatedIdentifierType": "URL"
+    }
+  ],
+  "relatedItems": [],
+  "sizes": [],
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [
+    {
+      "lang": "en-US",
+      "description": "The Pilatus 6M pixel-detector at the MX station 14.1",
+      "descriptionType": "Abstract"
+    },
+    {
+      "lang": "en-US",
+      "description": "Model Name: PILATUS3 S 6M. Instrument type: Raster image pixel detector. Measured variables: X-ray.",
+      "descriptionType": "TechnicalInfo"
+    }
+  ],
+  "url": "https://github.com/rdawg-pidinst/schema/blob/master/support/examples/hzb-mx-14-1-pilatus.xml",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/4.5/datacite-example-instrument-v4.xml
+++ b/tests/data/4.5/datacite-example-instrument-v4.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example: Instrument -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/08QF-EE96</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Organizational">DECTRIS</creatorName>
+      <nameIdentifier schemeURI="https://www.wikidata.org/wiki/" nameIdentifierScheme="Wikidata">Q107529885</nameIdentifier>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en-US">Pilatus detector at MX station 14.1</title>
+  </titles>
+  <publisher xml:lang="en">Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences</publisher>
+  <publicationYear>2022</publicationYear>
+  <contributors>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">Helmholtz-Zentrum Berlin für Materialien und Energie</contributorName>
+      <nameIdentifier schemeURI="https://ror.org/" nameIdentifierScheme="ROR">https://ror.org/02aj13c28</nameIdentifier>
+    </contributor>
+  </contributors>
+  <resourceType resourceTypeGeneral="Instrument">Raster image pixel detector</resourceType>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="SerialNumber">1234567</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="Handle" relationType="IsPartOf" resourceTypeGeneral="Instrument">1234.1675</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsDescribedBy" resourceTypeGeneral="Text">https://www.dectris.com/products/pilatus3/pilatus3-s-for-synchrotron/details/pilatus3-s-6m</relatedIdentifier>
+  </relatedIdentifiers>
+  <descriptions>
+    <description xml:lang="en-US" descriptionType="Abstract">The Pilatus 6M pixel-detector at the MX station 14.1</description>
+    <description xml:lang="en-US" descriptionType="TechnicalInfo">Model Name: PILATUS3 S 6M. Instrument type: Raster image pixel detector. Measured variables: X-ray.</description>
+  </descriptions>
+</resource>

--- a/tests/data/4.5/datacite-example-multilingual-v4.json
+++ b/tests/data/4.5/datacite-example-multilingual-v4.json
@@ -1,0 +1,150 @@
+{
+  "doi": "10.82433/byt7-2g42",
+  "prefix": "10.82433",
+  "suffix": "byt7-2g42",
+  "alternateIdentifiers": [],
+  "creators": [
+    {
+      "name": "Zou, Jing",
+      "nameType": "Personal",
+      "givenName": "Jing",
+      "familyName": "Zou",
+      "affiliation": [],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://orcid.org",
+          "nameIdentifier": "https://orcid.org/0000-0002-4553-2743",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
+    },
+    {
+      "name": "DataCite",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/04wxnsj81",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "Advances in Chemistry"
+    },
+    {
+      "lang": "es",
+      "title": "Avances en Química",
+      "titleType": "TranslatedTitle"
+    },
+    {
+      "lang": "zh",
+      "title": "化学进展",
+      "titleType": "TranslatedTitle"
+    }
+  ],
+  "publisher": {
+    "lang": "en",
+    "name": "DataCite",
+    "schemeUri": "https://ror.org/",
+    "publisherIdentifier": "https://ror.org/04wxnsj81",
+    "publisherIdentifierScheme": "ROR"
+  },
+  "container": {
+    "type": "Series",
+    "identifier": "arXiv:0706.0001",
+    "identifierType": "arXiv"
+  },
+  "publicationYear": "2022",
+  "subjects": [
+    {
+      "lang": "en",
+      "subject": "Chemistry"
+    },
+    {
+      "lang": "es",
+      "subject": "Químicas"
+    },
+    {
+      "lang": "zh",
+      "subject": "化学"
+    }
+  ],
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2024-01-01",
+      "dateType": "Available"
+    },
+    {
+      "date": "2022",
+      "dateType": "Issued"
+    }
+  ],
+  "language": "en",
+  "types": {
+    "resourceTypeGeneral": "BookChapter"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsPartOf",
+      "relatedIdentifier": "arXiv:0706.0001",
+      "resourceTypeGeneral": "Book",
+      "relatedIdentifierType": "arXiv"
+    }
+  ],
+  "relatedItems": [],
+  "sizes": [],
+  "formats": [],
+  "rightsList": [
+    {
+      "lang": "en",
+      "rights": "Creative Commons Attribution 4.0 International",
+      "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
+      "schemeUri": "https://spdx.org/licenses/",
+      "rightsIdentifier": "cc-by-4.0",
+      "rightsIdentifierScheme": "SPDX"
+    },
+    {
+      "lang": "es",
+      "rights": "Creative Commons Attribution 4.0 International",
+      "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
+      "schemeUri": "https://spdx.org/licenses/",
+      "rightsIdentifier": "cc-by-4.0",
+      "rightsIdentifierScheme": "SPDX"
+    },
+    {
+      "lang": "zh",
+      "rights": "Creative Commons Attribution 4.0 International",
+      "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
+      "schemeUri": "https://spdx.org/licenses/",
+      "rightsIdentifier": "cc-by-4.0",
+      "rightsIdentifierScheme": "SPDX"
+    }
+  ],
+  "descriptions": [
+    {
+      "lang": "en",
+      "description": "This chapter reviews selected landmarks ocurred in Chemistry basic research in the last 5 years",
+      "descriptionType": "Abstract"
+    },
+    {
+      "lang": "es",
+      "description": "El capítulo repasa los principales avances en la investigación básica en Ciencias Químicas en los últimos 5 años",
+      "descriptionType": "Abstract"
+    },
+    {
+      "lang": "zh",
+      "description": "本章回顾了过去5年中在化学基础研究中发生的一些里程碑式的事件",
+      "descriptionType": "Abstract"
+    }
+  ],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "url": "https://example.org",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/4.5/datacite-example-multilingual-v4.xml
+++ b/tests/data/4.5/datacite-example-multilingual-v4.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example with metadata in multiple languages -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/BYT7-2G42</identifier>
+  <titles>
+    <title xml:lang="en">Advances in Chemistry</title>
+    <title xml:lang="es" titleType="TranslatedTitle">Avances en Química</title>
+    <title xml:lang="zh" titleType="TranslatedTitle">化学进展</title>
+  </titles>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Zou, Jing</creatorName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-4553-2743</nameIdentifier>
+    </creator>
+    <creator>
+      <creatorName xml:lang="en" nameType="Organizational">DataCite</creatorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/04wxnsj81</nameIdentifier>
+    </creator>
+  </creators>
+  <publisher xml:lang="en" publisherIdentifier="https://ror.org/04wxnsj81" publisherIdentifierScheme="ROR" schemeURI="https://ror.org/">DataCite</publisher>
+  <publicationYear>2022</publicationYear>
+  <resourceType resourceTypeGeneral="BookChapter"/>
+  <subjects>
+    <subject xml:lang="en">Chemistry</subject>
+    <subject xml:lang="es">Químicas</subject>
+    <subject xml:lang="zh">化学</subject>
+  </subjects>
+  <dates>
+    <date dateType="Available">2024-01-01</date>
+  </dates>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">This chapter reviews selected landmarks ocurred in Chemistry basic research in the last 5 years</description>
+    <description xml:lang="es" descriptionType="Abstract">El capítulo repasa los principales avances en la investigación básica en Ciencias Químicas en los últimos 5 años</description>
+    <description xml:lang="zh" descriptionType="Abstract">本章回顾了过去5年中在化学基础研究中发生的一些里程碑式的事件</description>
+  </descriptions>
+  <language>en</language>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsPartOf" resourceTypeGeneral="Book">arXiv:0706.0001</relatedIdentifier>
+  </relatedIdentifiers>
+  <rightsList>
+    <rights xml:lang="en" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC-BY-4.0" rightsURI="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</rights>
+    <rights xml:lang="es" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC-BY-4.0" rightsURI="https://creativecommons.org/licenses/by/4.0/">Atribución 4.0 Internacional</rights>
+    <rights xml:lang="zh" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC-BY-4.0" rightsURI="https://creativecommons.org/licenses/by/4.0/">署名 4.0 国际</rights>
+  </rightsList>
+</resource>

--- a/tests/data/4.5/datacite-example-relateditem1-v4.json
+++ b/tests/data/4.5/datacite-example-relateditem1-v4.json
@@ -1,0 +1,89 @@
+{
+  "doi": "10.82433/q54d-pf76",
+  "prefix": "10.82433",
+  "suffix": "q54d-pf76",
+  "alternateIdentifiers": [],
+  "creators": [
+    {
+      "name": "Garcia, Sofia",
+      "nameType": "Personal",
+      "givenName": "Sofia",
+      "familyName": "Garcia",
+      "affiliation": [
+        {
+          "name": "Arizona State University",
+          "schemeUri": "https://ror.org",
+          "affiliationIdentifier": "https://ror.org/03efmqc40"
+        }
+      ],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://orcid.org",
+          "nameIdentifier": "https://orcid.org/0000-0001-5727-2427",
+          "nameIdentifierScheme": "ORCID"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "Example Article Title"
+    }
+  ],
+  "publisher": {
+    "name": "Example Publisher"
+  },
+  "container": {},
+  "publicationYear": "2022",
+  "subjects": [],
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2022",
+      "dateType": "Issued"
+    }
+  ],
+  "types": {
+    "resourceType": "ScholarlyArticle",
+    "resourceTypeGeneral": "JournalArticle"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsPublishedIn",
+      "relatedIdentifier": "1234-5678",
+      "relatedIdentifierType": "ISSN"
+    }
+  ],
+  "relatedItems": [
+    {
+      "issue": "4",
+      "titles": [
+        {
+          "title": "Journal of Metadata Examples"
+        }
+      ],
+      "volume": "3",
+      "creators": [],
+      "lastPage": "35",
+      "firstPage": "20",
+      "publisher": "Example Publisher",
+      "contributors": [],
+      "relationType": "IsPublishedIn",
+      "publicationYear": "2022",
+      "relatedItemType": "Journal",
+      "relatedItemIdentifier": {
+        "relatedItemIdentifier": "1234-5678",
+        "relatedItemIdentifierType": "ISSN"
+      }
+    }
+  ],
+  "sizes": [],
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "url": "https://example.org/RelatedItem1",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/4.5/datacite-example-relateditem1-v4.xml
+++ b/tests/data/4.5/datacite-example-relateditem1-v4.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example for RelatedItem: Journal article in a journal (with ISSN) -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/Q54D-PF76</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Garcia, Sofia</creatorName>
+      <givenName>Sofia</givenName>
+      <familyName>Garcia</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427</nameIdentifier>
+      <affiliation affiliationIdentifier="https://ror.org/03efmqc40" schemeURI="https://ror.org">Arizona State University</affiliation>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Example Article Title</title>
+  </titles>
+  <publisher>Example Publisher</publisher>
+  <publicationYear>2022</publicationYear>
+  <resourceType resourceTypeGeneral="JournalArticle">ScholarlyArticle</resourceType>
+  <dates>
+    <date dateType="Issued">2022</date>
+  </dates>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="ISSN" relationType="IsPublishedIn">1234-5678</relatedIdentifier>
+  </relatedIdentifiers>
+  <relatedItems>
+    <relatedItem relatedItemType="Journal" relationType="IsPublishedIn">
+      <relatedItemIdentifier relatedItemIdentifierType="ISSN">1234-5678</relatedItemIdentifier>
+      <titles>
+        <title>Journal of Metadata Examples</title>
+      </titles>
+      <publicationYear>2022</publicationYear>
+      <volume>3</volume>
+      <issue>4</issue>
+      <firstPage>20</firstPage>
+      <lastPage>35</lastPage>
+      <publisher>Example Publisher</publisher>
+    </relatedItem>
+  </relatedItems>
+</resource>

--- a/tests/data/4.5/datacite-example-relateditem2-v4.json
+++ b/tests/data/4.5/datacite-example-relateditem2-v4.json
@@ -1,0 +1,78 @@
+{
+
+      "doi": "10.82433/eck0-f231",
+      "prefix": "10.82433",
+      "suffix": "eck0-f231",
+      "alternateIdentifiers": [],
+      "creators": [
+        {
+          "name": "Garcia, Sofia",
+          "nameType": "Personal",
+          "givenName": "Sofia",
+          "familyName": "Garcia",
+          "affiliation": [],
+          "nameIdentifiers": []
+        }
+      ],
+      "titles": [
+        {
+          "lang": "en",
+          "title": "Example Chapter Title"
+        }
+      ],
+      "publisher": {
+        "lang": "en",
+        "name": "Example Publisher"
+      },
+      "container": {},
+      "publicationYear": "1980",
+      "subjects": [],
+      "contributors": [],
+      "dates": [
+        {
+          "date": "1980",
+          "dateType": "Issued"
+        }
+      ],
+      "types": {
+        "resourceTypeGeneral": "BookChapter"
+      },
+      "relatedIdentifiers": [],
+      "relatedItems": [
+        {
+          "titles": [
+            {
+              "title": "Example Book Title"
+            }
+          ],
+          "volume": "I",
+          "edition": "2nd edition",
+          "creators": [],
+          "lastPage": "155",
+          "firstPage": "110",
+          "publisher": "Example Publisher",
+          "contributors": [
+            {
+              "name": "Miller, Elizabeth",
+              "nameType": "Personal",
+              "givenName": "Elizabeth",
+              "familyName": "Miller",
+              "affiliation": [],
+              "contributorType": "Editor",
+              "nameIdentifiers": []
+            }
+          ],
+          "relationType": "IsPublishedIn",
+          "publicationYear": "1980",
+          "relatedItemType": "Book"
+        }
+      ],
+      "sizes": [],
+      "formats": [],
+      "rightsList": [],
+      "descriptions": [],
+      "geoLocations": [],
+      "fundingReferences": [],
+      "url": "https://example.org/RelatedItem2",
+      "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/4.5/datacite-example-relateditem2-v4.xml
+++ b/tests/data/4.5/datacite-example-relateditem2-v4.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example for RelatedItem: Digitized book chapter in a book (with no identifier) -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/ECK0-F231</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Garcia, Sofia</creatorName>
+      <givenName>Sofia</givenName>
+      <familyName>Garcia</familyName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Example Chapter Title</title>
+  </titles>
+  <publisher xml:lang="en">Example Publisher</publisher>
+  <publicationYear>1980</publicationYear>
+  <resourceType resourceTypeGeneral="BookChapter"/>
+  <relatedItems>
+    <relatedItem relationType="IsPublishedIn" relatedItemType="Book">
+      <titles>
+        <title>Example Book Title</title>
+      </titles>
+      <publicationYear>1980</publicationYear>
+      <volume>I</volume>
+      <firstPage>110</firstPage>
+      <lastPage>155</lastPage>
+      <publisher>Example Publisher</publisher>
+      <edition>2nd edition</edition>
+      <contributors>
+        <contributor contributorType="Editor">
+          <contributorName nameType="Personal">Miller, Elizabeth</contributorName>
+        </contributor>
+      </contributors>
+    </relatedItem>
+  </relatedItems>
+</resource>

--- a/tests/data/4.5/datacite-example-relateditem3-v4.json
+++ b/tests/data/4.5/datacite-example-relateditem3-v4.json
@@ -1,0 +1,84 @@
+{
+  "doi": "10.82433/4fdh-rh04",
+  "prefix": "10.82433",
+  "suffix": "4fdh-rh04",
+  "alternateIdentifiers": [],
+  "creators": [
+    {
+      "name": "Garcia, Sofia",
+      "nameType": "Personal",
+      "givenName": "Sofia",
+      "familyName": "Garcia",
+      "affiliation": [],
+      "nameIdentifiers": []
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "Example Chapter Title"
+    }
+  ],
+  "publisher": {
+    "lang": "en",
+    "name": "Example Publisher"
+  },
+  "container": {},
+  "publicationYear": "2016",
+  "subjects": [],
+  "contributors": [],
+  "dates": [
+    {
+      "date": "2016",
+      "dateType": "Issued"
+    }
+  ],
+  "types": {
+    "resourceTypeGeneral": "BookChapter"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsPublishedIn",
+      "relatedIdentifier": "0-12-345678-1",
+      "relatedIdentifierType": "ISBN"
+    }
+  ],
+  "relatedItems": [
+    {
+      "number": "4",
+      "titles": [
+        {
+          "title": "Example Book Title"
+        }
+      ],
+      "creators": [
+        {
+          "name": "Garcia, Sofia",
+          "nameType": "Personal",
+          "givenName": "Sofia",
+          "familyName": "Garcia"
+        }
+      ],
+      "lastPage": "63",
+      "firstPage": "45",
+      "publisher": "Example Publisher",
+      "numberType": "Chapter",
+      "contributors": [],
+      "relationType": "IsPublishedIn",
+      "publicationYear": "2016",
+      "relatedItemType": "Book",
+      "relatedItemIdentifier": {
+        "relatedItemIdentifier": "0-12-345678-1",
+        "relatedItemIdentifierType": "ISBN"
+      }
+    }
+  ],
+  "sizes": [],
+  "formats": [],
+  "rightsList": [],
+  "descriptions": [],
+  "geoLocations": [],
+  "fundingReferences": [],
+  "url": "https://example.org/RelatedItem3",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/4.5/datacite-example-relateditem3-v4.xml
+++ b/tests/data/4.5/datacite-example-relateditem3-v4.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example for RelatedItem: Digitized book chapter in a book (with an ISBN) -->
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/4FDH-RH04</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Garcia, Sofia</creatorName>
+      <givenName>Sofia</givenName>
+      <familyName>Garcia</familyName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Example Chapter Title</title>
+  </titles>
+  <publisher xml:lang="en">Example Publisher</publisher>
+  <publicationYear>2016</publicationYear>
+  <resourceType resourceTypeGeneral="BookChapter"/>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="ISBN" relationType="IsPublishedIn">0-12-345678-1</relatedIdentifier>
+  </relatedIdentifiers>
+  <relatedItems>
+    <relatedItem relationType="IsPublishedIn" relatedItemType="Book">
+      <relatedItemIdentifier relatedItemIdentifierType="ISBN">0-12-345678-1</relatedItemIdentifier>
+      <creators>
+        <creator>
+          <creatorName nameType="Personal">Garcia, Sofia</creatorName>
+          <givenName>Sofia</givenName>
+          <familyName>Garcia</familyName>
+        </creator>
+      </creators>
+      <titles>
+        <title>Example Book Title</title>
+      </titles>
+      <publicationYear>2016</publicationYear>
+      <number numberType="Chapter">4</number>
+      <firstPage>45</firstPage>
+      <lastPage>63</lastPage>
+      <publisher>Example Publisher</publisher>
+    </relatedItem>
+  </relatedItems>
+</resource>

--- a/tests/data/4.5/include/datacite-contributorType-v4.xsd
+++ b/tests/data/4.5/include/datacite-contributorType-v4.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+   2013-05 v3.0: Addition of ID to simpleType element, added values "ResearchGroup" & "Other"
+   2014-08-20 v3.1: Addition of value "DataCurator"
+   2015-05-14 v4.0 dropped value "Funder", use new "funderReference" -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="contributorType" id="contributorType">
+    <xs:annotation>
+      <xs:documentation>The type of contributor of the resource.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ContactPerson" />
+      <xs:enumeration value="DataCollector" />
+      <xs:enumeration value="DataCurator" />
+      <xs:enumeration value="DataManager" />
+      <xs:enumeration value="Distributor" />
+      <xs:enumeration value="Editor" />
+      <xs:enumeration value="HostingInstitution" />
+      <xs:enumeration value="Other" />
+      <xs:enumeration value="Producer" />
+      <xs:enumeration value="ProjectLeader" />
+      <xs:enumeration value="ProjectManager" />
+      <xs:enumeration value="ProjectMember" />
+      <xs:enumeration value="RegistrationAgency" />
+      <xs:enumeration value="RegistrationAuthority" />
+      <xs:enumeration value="RelatedPerson" />
+      <xs:enumeration value="ResearchGroup" />
+      <xs:enumeration value="RightsHolder" />
+      <xs:enumeration value="Researcher" />
+      <xs:enumeration value="Sponsor" />
+      <xs:enumeration value="Supervisor" />
+      <xs:enumeration value="WorkPackageLeader" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-dateType-v4.xsd
+++ b/tests/data/4.5/include/datacite-dateType-v4.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+     2013-05 v3.0: Addition of ID to simpleType element; addition of value "Collected"; deleted "StartDate" & "EndDate"
+     2017-10-23 v4.1: Addition of value "Other"
+     2019-02-14 v4.2: Addition of value "Withdrawn"-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="dateType" id="dateType">
+    <xs:annotation>
+      <xs:documentation>The type of date. Use RKMS‐ISO8601 standard for depicting date ranges.To indicate the end of an embargo period, use Available. To indicate the start of an embargo period, use Submitted or Accepted, as appropriate.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Accepted" />
+      <xs:enumeration value="Available" />
+      <xs:enumeration value="Collected" />
+      <xs:enumeration value="Copyrighted" />
+      <xs:enumeration value="Created" />
+      <xs:enumeration value="Issued" />
+      <xs:enumeration value="Other" />
+      <xs:enumeration value="Submitted" />
+      <xs:enumeration value="Updated" />
+      <xs:enumeration value="Valid" />
+      <xs:enumeration value="Withdrawn" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-descriptionType-v4.xsd
+++ b/tests/data/4.5/include/datacite-descriptionType-v4.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+     2013-05 v3.0: Addition of ID to simpleType element, addition of value "Methods"
+     2015-02-12 v4.0: Addition of value "TechnicalInfo"-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="descriptionType" id="descriptionType">
+    <xs:annotation>
+      <xs:documentation>The type of the description.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Abstract" />
+      <xs:enumeration value="Methods" />
+      <xs:enumeration value="SeriesInformation" />
+      <xs:enumeration value="TableOfContents" />
+      <xs:enumeration value="TechnicalInfo" />
+      <xs:enumeration value="Other" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-funderIdentifierType-v4.xsd
+++ b/tests/data/4.5/include/datacite-funderIdentifierType-v4.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2016-05-14 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="funderIdentifierType" id="funderIdentifierType">
+    <xs:annotation>
+      <xs:documentation>The type of the funderIdentifier.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ISNI" />
+      <xs:enumeration value="GRID" />
+      <xs:enumeration value="ROR" />
+      <xs:enumeration value="Crossref Funder ID" />
+      <xs:enumeration value="Other" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-nameType-v4.xsd
+++ b/tests/data/4.5/include/datacite-nameType-v4.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 4.1 - Created 2017-10-23 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="nameType" id="nameType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Organizational" />
+      <xs:enumeration value="Personal" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-numberType-v4.xsd
+++ b/tests/data/4.5/include/datacite-numberType-v4.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 4.4 - Created 2021-03-05 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="numberType" id="numberType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Article" />
+      <xs:enumeration value="Chapter" />
+      <xs:enumeration value="Report" />
+      <xs:enumeration value="Other" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-relatedIdentifierType-v4.xsd
+++ b/tests/data/4.5/include/datacite-relatedIdentifierType-v4.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+  2013-05 v3.0: Addition of ID to simpleType element; addition of value "PMID"
+  2014-08-20 v3.1: Addition of values "arxiv" and "bibcode"
+  2015-02-12 v4.0 Addition of value "IGSN"
+  2019-02-14 v4.2 Addition of value "w3id" -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="relatedIdentifierType" id="relatedIdentifierType">
+    <xs:annotation>
+      <xs:documentation>The type of the RelatedIdentifier.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ARK" />
+      <xs:enumeration value="arXiv" />
+      <xs:enumeration value="bibcode" />
+      <xs:enumeration value="DOI" />
+      <xs:enumeration value="EAN13" />
+      <xs:enumeration value="EISSN" />
+      <xs:enumeration value="Handle" />
+      <xs:enumeration value="IGSN" />
+      <xs:enumeration value="ISBN" />
+      <xs:enumeration value="ISSN" />
+      <xs:enumeration value="ISTC" />
+      <xs:enumeration value="LISSN" />
+      <xs:enumeration value="LSID" />
+      <xs:enumeration value="PMID" />
+      <xs:enumeration value="PURL" />
+      <xs:enumeration value="UPC" />
+      <xs:enumeration value="URL" />
+      <xs:enumeration value="URN" />
+      <xs:enumeration value="w3id" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-relationType-v4.xsd
+++ b/tests/data/4.5/include/datacite-relationType-v4.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  2011-01-13 v1.0 - FZ, TIB, Germany
+  2013-05 v3.0: Addition of ID to simpleType element, addition of values "IsIdenticalTo", "HasMetadata" & "IsMetadataFor"
+  2014-08-20 v3.1: Addition of values "Reviews" & "IsReviewedBy" and "IsDerivedFrom" & "IsSourceOf"
+  2017-10-23 v.4.1: Addition of values "Describes", "IsDescribedBy", "HasVersion", "IsVersionOf", "Requires", "IsRequiredBy"
+  2019-02-14 v.4.2: Addition of values "Obsoletes", "IsObsoletedBy"
+  2021-03-05 v.4.4: Addition of value "IsPublishedIn" -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="relationType" id="relationType">
+    <xs:annotation>
+      <xs:documentation>Description of the relationship of the resource being registered (A) and the related resource (B).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="IsCitedBy" />
+      <xs:enumeration value="Cites" />
+      <xs:enumeration value="IsSupplementTo" />
+      <xs:enumeration value="IsSupplementedBy" />
+      <xs:enumeration value="IsContinuedBy" />
+      <xs:enumeration value="Continues" />
+      <xs:enumeration value="IsNewVersionOf" />
+      <xs:enumeration value="IsPreviousVersionOf" />
+      <xs:enumeration value="IsPartOf" />
+      <xs:enumeration value="HasPart" />
+      <xs:enumeration value="IsPublishedIn" />
+      <xs:enumeration value="IsReferencedBy" />
+      <xs:enumeration value="References" />
+      <xs:enumeration value="IsDocumentedBy" />
+      <xs:enumeration value="Documents" />
+      <xs:enumeration value="IsCompiledBy" />
+      <xs:enumeration value="Compiles" />
+      <xs:enumeration value="IsVariantFormOf" />
+      <xs:enumeration value="IsOriginalFormOf" />
+      <xs:enumeration value="IsIdenticalTo" />
+      <xs:enumeration value="HasMetadata" />
+      <xs:enumeration value="IsMetadataFor" />
+      <xs:enumeration value="Reviews" />
+      <xs:enumeration value="IsReviewedBy" />
+      <xs:enumeration value="IsDerivedFrom" />
+      <xs:enumeration value="IsSourceOf" />
+      <xs:enumeration value="Describes" />
+      <xs:enumeration value="IsDescribedBy" />
+      <xs:enumeration value="HasVersion" />
+      <xs:enumeration value="IsVersionOf" />
+      <xs:enumeration value="Requires" />
+      <xs:enumeration value="IsRequiredBy" />
+      <xs:enumeration value="Obsoletes" />
+      <xs:enumeration value="IsObsoletedBy" />
+      <xs:enumeration value="Collects" />
+      <xs:enumeration value="IsCollectedBy" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-resourceType-v4.xsd
+++ b/tests/data/4.5/include/datacite-resourceType-v4.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+     2013-05 v3.0: Addition of ID to simpleType element; added values "Audiovisual", "Workflow" & "Other"; deleted value "Film"
+     2017-10-23 v4.1: Addition of value "DataPaper"
+     2020-01-14 v4.4: Addition of values "Book", "Book Chapter", "ComputationalNotebook", "ConferencePaper", "ConferenceProceeding".
+       "Dissertation", "Journal", "JournalArticle", "OutputManagementPlan", "PeerReview", "Preprint", "Report" -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="resourceType" id="resourceType">
+    <xs:annotation>
+      <xs:documentation>The general type of a resource.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Audiovisual" />
+      <xs:enumeration value="Book" />
+      <xs:enumeration value="BookChapter" />
+      <xs:enumeration value="Collection" />
+      <xs:enumeration value="ComputationalNotebook" />
+      <xs:enumeration value="ConferencePaper" />
+      <xs:enumeration value="ConferenceProceeding" />
+      <xs:enumeration value="DataPaper" />
+      <xs:enumeration value="Dataset" />
+      <xs:enumeration value="Dissertation" />
+      <xs:enumeration value="Event" />
+      <xs:enumeration value="Image" />
+      <xs:enumeration value="Instrument" />
+      <xs:enumeration value="InteractiveResource" />
+      <xs:enumeration value="Journal" />
+      <xs:enumeration value="JournalArticle" />
+      <xs:enumeration value="Model" />
+      <xs:enumeration value="OutputManagementPlan" />
+      <xs:enumeration value="PeerReview" />
+      <xs:enumeration value="PhysicalObject" />
+      <xs:enumeration value="Preprint" />
+      <xs:enumeration value="Report" />
+      <xs:enumeration value="Service" />
+      <xs:enumeration value="Software" />
+      <xs:enumeration value="Sound" />
+      <xs:enumeration value="Standard" />
+      <xs:enumeration value="StudyRegistration" />
+      <xs:enumeration value="Text" />
+      <xs:enumeration value="Workflow" />
+      <xs:enumeration value="Other" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/datacite-titleType-v4.xsd
+++ b/tests/data/4.5/include/datacite-titleType-v4.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version 1.0 - Created 2011-01-13 - FZ, TIB, Germany
+  2013-05 v3.0: Addition of ID to simpleType element
+  2015-02-12 v4.0 Added value "Other" -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified">
+  <xs:simpleType name="titleType" id="titleType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AlternativeTitle" />
+      <xs:enumeration value="Subtitle" />
+      <xs:enumeration value="TranslatedTitle" />
+      <xs:enumeration value="Other" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/4.5/include/xml.xsd
+++ b/tests/data/4.5/include/xml.xsd
@@ -1,0 +1,286 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>

--- a/tests/data/4.5/metadata.xsd
+++ b/tests/data/4.5/metadata.xsd
@@ -1,0 +1,711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Revision history
+  2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
+  2010-11-17 Revised to current state of kernel review, FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
+  2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
+  2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
+  2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
+  2014-08-20 v3.1: additions to controlled lists "relationType", contributorType" and "relatedIdentifierType"; introduction of new child element "affiliation" to "creator" and "contributor"
+  2016-09-19 v4.0: namespace: kernel-4.0; makes "resourceType" required field, added optional "givenName" and "familyName" to creator and contributor, added "funderReference", added "valueURI" for subject, added "geoLocationPolygon"
+  2017-10-23 v4.1: Addition of dateType value "Other", relationType values "Describes", "IsDescribedBy", "HasVersion", "IsVersionOf", "Requires", "IsRequiredBy", resourceType value "DataPaper", new subproperties "dateInformation", "inPolygonPoint", new attribute "nameType", optional attribute "resourceTypeGeneral" for relatedIdentifier 
+  2018-09-08 v4.1.1 Make schema 4.1 backwards compatible to 4.0 by allowing geolocation elements in any order
+  2019-02-14 v4.2: Addition of dateType value "Withdrawn", relationType values "Obsoletes", "isObsoletedBy", addition of new subproperties for Rights: rightsIdentifier, rightsIdentifierScheme, schemeURI, addition of the XML language attribute to the properties Creator, Contributor and Publisher for organizational names, don't check format of DOI
+  2019-07-13 v4.3: Addition of new subproperties for Affiliation: "affiliationIdentifier", "affiliationIdentifierScheme", "schemeURI", addition of new sub-property for funderIdentifier: "schemeURI", addition of new funderIdentifierScheme: "ROR", added documentation for nameIdentifier 
+  2021-03-08 v4.4: Addition of new property relatedItem, relationType value "isPublishedIn", subject subproperty "classificationCode", controlled list "numberType", additional 13 properties for controlled list "resourceType" 
+  2024-01-22 v4.5: Addition of new subproperties for publisher: "publisherIdentifier", "publisherIdentifierScheme", and "schemeURI"; addition of new resourceTypeGeneral values "Instrument" and "StudyRegistration"; addition of new relationType values "Collects" and "IsCollectedBy".-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" targetNamespace="http://datacite.org/schema/kernel-4" elementFormDefault="qualified" xml:lang="EN">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="include/xml.xsd" />
+  <xs:include schemaLocation="include/datacite-titleType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-contributorType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-dateType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-resourceType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-relationType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-relatedIdentifierType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-funderIdentifierType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-descriptionType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-nameType-v4.xsd" />
+  <xs:include schemaLocation="include/datacite-numberType-v4.xsd" />
+  <xs:element name="resource">
+    <xs:annotation>
+      <xs:documentation>
+        Root element of a single record. This wrapper element is for XML implementation only and is not defined in the DataCite DOI standard.
+        Note: This is the case for all wrapper elements within this schema.</xs:documentation>
+      <xs:documentation>No content in this wrapper element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <!--REQUIRED FIELDS-->
+        <xs:element name="identifier">
+          <xs:annotation>
+            <xs:documentation>A persistent identifier that identifies a resource.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="nonemptycontentStringType">
+                <xs:attribute name="identifierType" use="required" />
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="creators">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="creator" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>The main researchers involved working on the data, or the authors of the publication in priority order. May be a corporate/institutional or personal name.</xs:documentation>
+                  <xs:documentation>Format: Family, Given.</xs:documentation>
+                  <xs:documentation>Personal names can be further specified using givenName and familyName.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="creatorName">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="nameType" type="nameType" use="optional" />
+                            <xs:attribute ref="xml:lang" />
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="givenName" minOccurs="0" />
+                    <xs:element name="familyName" minOccurs="0" />
+                    <xs:element name="nameIdentifier" xsi:type="nameIdentifier" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element name="affiliation" xsi:type="affiliation" minOccurs="0" maxOccurs="unbounded" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="titles">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="title" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>A name or title by which a resource is known.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="titleType" type="titleType" use="optional" />
+                      <xs:attribute ref="xml:lang" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="publisher">
+          <xs:annotation>
+            <xs:documentation>The name of the entity that holds, archives, publishes prints, distributes, releases, issues, or produces the resource. This property will be used to formulate the citation, so consider the prominence of the role.</xs:documentation>
+            <xs:documentation>In the case of datasets, "publish" is understood to mean making the data available to the community of researchers.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="nonemptycontentStringType">
+                <xs:attribute name="publisherIdentifier" type="xs:string" use="optional" />
+                <xs:attribute name="publisherIdentifierScheme" type="xs:string" use="optional" />
+                <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+                <xs:attribute ref="xml:lang" />
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="publicationYear">
+          <xs:annotation>
+            <xs:documentation>Year when the data is made publicly available. If an embargo period has been in effect, use the date when the embargo period ends.</xs:documentation>
+            <xs:documentation>In the case of datasets, "publish" is understood to mean making the data available on a specific date to the community of researchers. If there is no standard publication year value, use the date that would be preferred from a citation perspective.</xs:documentation>
+            <xs:documentation>YYYY</xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="yearType" />
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="resourceType">
+          <xs:annotation>
+            <xs:documentation>The type of a resource. You may enter an additional free text description.</xs:documentation>
+            <xs:documentation>The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="resourceTypeGeneral" type="resourceType" use="required" />
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <!--OPTIONAL FIELDS-->
+        <xs:element name="subjects" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="subject" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Subject, keywords, classification codes, or key phrases describing the resource.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="subjectScheme" use="optional" />
+                      <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+                      <xs:attribute name="valueURI" type="xs:anyURI" use="optional" />
+                      <xs:attribute name="classificationCode" type="xs:anyURI" use="optional" />
+                      <xs:attribute ref="xml:lang" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="contributors" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
+                  <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="contributorName">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="nonemptycontentStringType">
+                            <xs:attribute name="nameType" type="nameType" use="optional" />
+                            <xs:attribute ref="xml:lang" />
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="givenName" minOccurs="0" />
+                    <xs:element name="familyName" minOccurs="0" />
+                    <xs:element name="nameIdentifier" xsi:type="nameIdentifier" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element name="affiliation" xsi:type="affiliation" minOccurs="0" maxOccurs="unbounded" />
+                  </xs:sequence>
+                  <xs:attribute name="contributorType" type="contributorType" use="required" />
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="dates" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="date" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Different dates relevant to the work.</xs:documentation>
+                  <xs:documentation>YYYY,YYYY-MM-DD, YYYY-MM-DDThh:mm:ssTZD or any other format or level of granularity described in W3CDTF. Use RKMS-ISO8601 standard for depicting date ranges.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="dateType" type="dateType" use="required" />
+                      <xs:attribute name="dateInformation" use="optional" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="language" type="xs:language" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="alternateIdentifiers" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="alternateIdentifier" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="alternateIdentifierType" use="required" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="relatedIdentifiers" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="relatedIdentifier" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Identifiers of related resources. Use this property to indicate subsets of properties, as appropriate.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="resourceTypeGeneral" type="resourceType" use="optional" />
+                      <xs:attribute name="relatedIdentifierType" type="relatedIdentifierType" use="required" />
+                      <xs:attribute name="relationType" type="relationType" use="required" />
+                      <xs:attribute name="relatedMetadataScheme" use="optional" />
+                      <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+                      <xs:attribute name="schemeType" use="optional" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="sizes" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="size" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Unstructures size information about the resource.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="formats" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Technical format of the resource.</xs:documentation>
+                  <xs:documentation>Use file extension or MIME type where possible.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="version" type="xs:string" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Version number of the resource. If the primary resource has changed the version number increases.</xs:documentation>
+            <xs:documentation>Register a new identifier for a major version change. Individual stewards need to determine which are major vs. minor versions. May be used in conjunction with properties 11 and 12 (AlternateIdentifier and RelatedIdentifier) to indicate various information updates. May be used in conjunction with property 17 (Description) to indicate the nature and file/record range of version.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="rightsList" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="rights" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Any rights information for this resource. Provide a rights management statement for the resource or reference a service providing such information. Include embargo information if applicable.
+Use the complete title of a license and include version information if applicable.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="rightsURI" type="xs:anyURI" use="optional" />
+                      <xs:attribute name="rightsIdentifier" use="optional" />
+                      <xs:attribute name="rightsIdentifierScheme" use="optional" />
+                      <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+                      <xs:attribute ref="xml:lang" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="descriptions" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="description" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>All additional information that does not fit in any of the other categories. May be used for technical information. It is a best practice to supply a description.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType mixed="true">
+                  <xs:choice>
+                    <xs:element name="br" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType />
+                    </xs:element>
+                  </xs:choice>
+                  <xs:attribute name="descriptionType" type="descriptionType" use="required" />
+                  <xs:attribute ref="xml:lang" />
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="geoLocations" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="geoLocation" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:choice maxOccurs="unbounded">
+                    <xs:element name="geoLocationPlace" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Spatial region or named place where the data was gathered or about which the data is focused.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="geoLocationPoint" type="point" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>A point contains a single latitude-longitude pair.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="geoLocationBox" type="box" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>A box contains two white space separated latitude-longitude pairs, with each pair separated by whitespace. The first pair is the lower corner, the second is the upper corner.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="geoLocationPolygon" minOccurs="0" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:documentation>A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="polygonPoint" type="point" minOccurs="4" maxOccurs="unbounded" />
+                          <xs:element name="inPolygonPoint" type="point" minOccurs="0" maxOccurs="1" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="fundingReferences" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="fundingReference" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Information about financial support (funding) for the resource being registered.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:all>
+                    <xs:element name="funderName" minOccurs="1" maxOccurs="1">
+                      <xs:annotation>
+                        <xs:documentation>Name of the funding provider.</xs:documentation>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="nonemptycontentStringType" />
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="funderIdentifier" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Uniquely identifies a funding entity, according to various types.</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="funderIdentifierType" type="funderIdentifierType" use="required" />
+                            <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="awardNumber" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>The code assigned by the funder to a sponsored award (grant).</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="awardURI" type="xs:anyURI" use="optional" />
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="awardTitle" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>The human readable title of the award (grant).</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:all>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="relatedItems" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="relatedItem" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:documentation>Information about a resource related to the one being registered e.g. a journal or book of which the article or chapter is part.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="relatedItemIdentifier" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>The identifier for the related item.</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="relatedItemIdentifierType" type="relatedIdentifierType" use="optional">
+                              <xs:annotation>
+                                <xs:documentation>The type of the Identifier for the related item e.g. DOI.</xs:documentation>
+                              </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="relatedMetadataScheme" use="optional">
+                              <xs:annotation>
+                                <xs:documentation>The name of the scheme.</xs:documentation>
+                              </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="schemeURI" type="xs:anyURI" use="optional">
+                              <xs:annotation>
+                                <xs:documentation>The URI of the relatedMetadataScheme.</xs:documentation>
+                              </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="schemeType" use="optional">
+                              <xs:annotation>
+                                <xs:documentation>The type of the relatedMetadataScheme, linked with the schemeURI.</xs:documentation>
+                              </xs:annotation>
+                            </xs:attribute>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="creators" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="creator" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                              <xs:documentation>The institution or person responsible for creating the 
+                                related resource. To supply multiple creators, repeat this property.
+                              </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="creatorName">
+                                  <xs:complexType>
+                                    <xs:simpleContent>
+                                      <xs:extension base="xs:string">
+                                        <xs:attribute name="nameType" type="nameType" use="optional" />
+                                        <xs:attribute ref="xml:lang" />
+                                      </xs:extension>
+                                    </xs:simpleContent>
+                                  </xs:complexType>
+                                </xs:element>
+                                <xs:element name="givenName" minOccurs="0" />
+                                <xs:element name="familyName" minOccurs="0" />
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="titles" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="title" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                              <xs:documentation>Title of the related item.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute name="titleType" type="titleType" use="optional" />
+                                  <xs:attribute ref="xml:lang" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="publicationYear" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>The year when the item was or will be made publicly available.</xs:documentation>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="yearType" />
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="volume" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Volume of the related item.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="issue" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Issue number or name of the related item.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="number" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Number of the related item e.g. report number of article number.</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="numberType" type="numberType" use="optional" />
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="firstPage" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>First page of the related item e.g. of the chapter, article, or conference paper.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="lastPage" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Last page of the related item e.g. of the chapter, article, or conference paper.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="publisher" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>The name of the entity that holds, archives, publishes prints, distributes, releases, issues, or produces the resource. This property will be used to formulate the citation, so consider the prominence of the role.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="edition" minOccurs="0">
+                      <xs:annotation>
+                        <xs:documentation>Edition or version of the related item.</xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="contributors" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                              <xs:documentation>The institution or person responsible for collecting, 
+                              managing, distributing, or otherwise contributing to the development of 
+                              the resource.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="contributorName">
+                                  <xs:complexType>
+                                    <xs:simpleContent>
+                                      <xs:extension base="xs:string">
+                                        <xs:attribute name="nameType" type="nameType" use="optional" />
+                                        <xs:attribute ref="xml:lang" />
+                                      </xs:extension>
+                                    </xs:simpleContent>
+                                  </xs:complexType>
+                                </xs:element>
+                                <xs:element name="givenName" minOccurs="0" />
+                                <xs:element name="familyName" minOccurs="0" />
+                              </xs:sequence>
+                              <xs:attribute name="contributorType" type="contributorType" use="required">
+                                <xs:annotation>
+                                  <xs:documentation>The type of contributor of the resource.</xs:documentation>
+                                </xs:annotation>
+                              </xs:attribute>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="relatedItemType" type="resourceType" use="required">
+                    <xs:annotation>
+                      <xs:documentation>The type of the related item, e.g. journal article, book or chapter.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="relationType" type="relationType" use="required">
+                    <xs:annotation>
+                      <xs:documentation>Description of the relationship of the resource being registered (A) and the related resource (B).</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- TYPE DECLARATIONS -->
+  <!-- defines value for mandatory fields -->
+  <xs:simpleType name="nonemptycontentStringType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!-- definition for nameIdentifier -->
+  <xs:complexType name="nameIdentifier">
+    <xs:annotation>
+      <xs:documentation>Uniquely identifies a creator or contributor, according to various identifier schemes.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="nonemptycontentStringType">
+        <xs:attribute name="nameIdentifierScheme" type="xs:string" use="required" />
+        <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- definition for EDTF dates, modified from PREMIS 2.0 -->
+  <xs:simpleType name="edtf">
+    <xs:restriction base="xs:string">
+      <!-- pattern for iso8601 dateTime -->
+      <xs:pattern value="(-)?[0-9]{4}(-[0-9]{2})?(-[0-9]{2})?(T([0-9]{2}:){2}[0-9]{2}Z)?" />
+
+      <!--  
+      The following pattern is for year (yyyy) or year-month (yyyy-mm)              
+      The last or last two digits of year may be '?'  meaning "one year in that range but not sure which year", for example 19?? means some year from 1990 to 1999.  Similarly month may be '??' so that 2004-?? "means some month in 2004".  And the entire string may end with '?' or '~' for "uncertain" or "approximate".
+      Hyphen must separate year and month.
+      -->
+      <xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??" />
+      <!--  
+      The following pattern is for  yearMonthDay - yyyymmdd,  where 'dd' may be '??'  so '200412??' means "some day during the month of 12/2004". 
+      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hyphens are  not allowed for this pattern. 
+      -->
+      <xs:pattern value="\d{6}(\d{2}|\?\?)~?\??" />
+      <!--  
+
+      The following pattern is for date and time with T separator:'yyyymmddThhmmss'. 
+      Hyphens in date and colons in time not allowed for this pattern.   
+      -->
+      <xs:pattern value="\d{8}T\d{6}" />
+      <!--  
+
+      The following pattern is for a date range. in years: 'yyyy/yyyy'; or year/month: yyyy-mm/yyyy-mm, or year/month/day: yyyy-mm-dd/yyyy-mm-dd. Beginning or end of range value may be 'unknown'. End of range value may be 'open'.
+      Hyphens mandatory when month is present. 
+      -->
+      <xs:pattern value="((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown)/((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown|open)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!-- definition for affiliation -->
+  <xs:complexType name="affiliation">
+    <xs:annotation>
+      <xs:documentation>Uniquely identifies an affiliation, according to various identifier schemes.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="nonemptycontentStringType">
+        <xs:attribute name="affiliationIdentifier" type="xs:string" use="optional" />
+        <xs:attribute name="affiliationIdentifierScheme" type="xs:string" use="optional" />
+        <xs:attribute name="schemeURI" type="xs:anyURI" use="optional" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- defines the value for a year -->
+  <xs:simpleType name="yearType">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[\d]{4}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!-- definitions for geoLocation -->
+  <xs:complexType name="point">
+    <xs:all>
+      <xs:element name="pointLongitude" type="longitudeType" minOccurs="1" />
+      <xs:element name="pointLatitude" type="latitudeType" minOccurs="1" />
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="box">
+    <xs:all>
+      <xs:element name="westBoundLongitude" type="longitudeType" minOccurs="1" />
+      <xs:element name="eastBoundLongitude" type="longitudeType" minOccurs="1" />
+      <xs:element name="southBoundLatitude" type="latitudeType" minOccurs="1" />
+      <xs:element name="northBoundLatitude" type="latitudeType" minOccurs="1" />
+    </xs:all>
+  </xs:complexType>
+  <xs:simpleType name="longitudeType">
+    <xs:restriction base="xs:float">
+      <xs:minInclusive value="-180" />
+      <xs:maxInclusive value="180" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="latitudeType">
+    <xs:restriction base="xs:float">
+      <xs:minInclusive value="-90" />
+      <xs:maxInclusive value="90" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/tests/data/datacite-v4.5-full-example.json
+++ b/tests/data/datacite-v4.5-full-example.json
@@ -1,0 +1,606 @@
+{
+  "doi": "10.82433/b09z-4k37",
+  "prefix": "10.82433",
+  "suffix": "b09z-4k37",
+  "alternateIdentifiers": [
+    {
+      "alternateIdentifierType": "Local accession number",
+      "alternateIdentifier": "12345"
+    }
+  ],
+  "creators": [
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "affiliation": [],
+      "nameIdentifiers": []
+    },
+    {
+      "name": "ExampleOrganization",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/03yrm5c26",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "Example Title"
+    },
+    {
+      "lang": "en",
+      "title": "Example Subtitle",
+      "titleType": "Subtitle"
+    },
+    {
+      "lang": "fr",
+      "title": "Example TranslatedTitle",
+      "titleType": "TranslatedTitle"
+    },
+    {
+      "lang": "en",
+      "title": "Example AlternativeTitle",
+      "titleType": "AlternativeTitle"
+    }
+  ],
+  "publisher": {
+    "lang": "en",
+    "name": "Example Publisher",
+    "schemeUri": "https://ror.org/",
+    "publisherIdentifier": "https://ror.org/04z8jg394",
+    "publisherIdentifierScheme": "ROR"
+  },
+  "container": {
+    "type": "DataRepository",
+    "title": "Example SeriesInformation",
+    "identifier": "http://purl.oclc.org/foo/bar",
+    "identifierType": "PURL"
+  },
+  "publicationYear": "2022",
+  "subjects": [
+    {
+      "subject": "FOS: Computer and information sciences",
+      "valueUri": "http://www.oecd.org/science/inno/38235147.pdf",
+      "schemeUri": "http://www.oecd.org/science/inno",
+      "subjectScheme": "Fields of Science and Technology (FOS)"
+    },
+    {
+      "subject": "FOS: Computer and information sciences",
+      "schemeUri": "http://www.oecd.org/science/inno/38235147.pdf",
+      "subjectScheme": "Fields of Science and Technology (FOS)"
+    },
+    {
+      "subject": "Digital curation and preservation",
+      "valueUri": "https://www.abs.gov.au/statistics/classifications/australian-and-new-zealand-standard-research-classification-anzsrc/2020",
+      "schemeUri": "https://www.abs.gov.au/statistics/classifications/australian-and-new-zealand-standard-research-classification-anzsrc",
+      "subjectScheme": "Australian and New Zealand Standard Research Classification (ANZSRC), 2020"
+    },
+    {
+      "subject": "Example Subject"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "ContactPerson",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "DataCollector",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "DataCurator",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "DataManager",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleOrganization",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "Distributor"
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "Editor",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleOrganization",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "HostingInstitution",
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/03yrm5c26",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "Producer",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "ProjectLeader",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "ProjectManager",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "ProjectMember",
+      "affiliation": []
+    },
+    {
+      "name": "DataCite",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "RegistrationAgency"
+    },
+    {
+      "name": "International DOI Foundation",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "RegistrationAuthority"
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "RelatedPerson",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "Researcher",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleContributor",
+      "affiliation": [
+        {
+          "name": "ExampleOrganization",
+          "schemeUri": "https://ror.org",
+          "affiliationIdentifier": "https://ror.org/03yrm5c26",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "contributorType": "ResearchGroup",
+      "nameIdentifiers": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "RightsHolder",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleContributor",
+      "affiliation": [
+        {
+          "name": "https://ror.org/03yrm5c26",
+          "schemeUri": "https://ror.org",
+          "affiliationIdentifier": "https://ror.org/03yrm5c26",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "contributorType": "Sponsor",
+      "nameIdentifiers": []
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "Supervisor",
+      "affiliation": []
+    },
+    {
+      "name": "ExampleOrganization",
+      "nameType": "Organizational",
+      "affiliation": [],
+      "contributorType": "WorkPackageLeader",
+      "nameIdentifiers": [
+        {
+          "schemeUri": "https://ror.org",
+          "nameIdentifier": "https://ror.org/03yrm5c26",
+          "nameIdentifierScheme": "ROR"
+        }
+      ]
+    },
+    {
+      "name": "ExampleFamilyName, ExampleGivenName",
+      "nameType": "Personal",
+      "givenName": "ExampleGivenName",
+      "familyName": "ExampleFamilyName",
+      "contributorType": "Other",
+      "affiliation": []
+    }
+  ],
+  "dates": [
+    {
+      "date": "2022-01-01",
+      "dateType": "Accepted"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Available"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Copyrighted"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Created"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Issued"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Submitted"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Updated"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Valid"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Withdrawn"
+    },
+    {
+      "date": "2022-01-01",
+      "dateType": "Other",
+      "dateInformation": "ExampleDateInformation"
+    }
+  ],
+  "language": "en",
+  "types": {
+    "resourceType": "Example ResourceType",
+    "resourceTypeGeneral": "Dataset"
+  },
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsCitedBy",
+      "relatedIdentifier": "ark:/13030/tqb3kh97gh8w",
+      "resourceTypeGeneral": "Audiovisual",
+      "relatedIdentifierType": "ARK"
+    },
+    {
+      "relationType": "Cites",
+      "relatedIdentifier": "arXiv:0706.0001",
+      "resourceTypeGeneral": "Book",
+      "relatedIdentifierType": "arXiv"
+    },
+    {
+      "relationType": "IsSupplementTo",
+      "relatedIdentifier": "2018AGUFM.A24K..07S",
+      "resourceTypeGeneral": "BookChapter",
+      "relatedIdentifierType": "bibcode"
+    },
+    {
+      "relationType": "IsSupplementedBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Collection",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsContinuedBy",
+      "relatedIdentifier": "9783468111242",
+      "resourceTypeGeneral": "ComputationalNotebook",
+      "relatedIdentifierType": "EAN13"
+    },
+    {
+      "relationType": "Continues",
+      "relatedIdentifier": "1562-6865",
+      "resourceTypeGeneral": "ConferencePaper",
+      "relatedIdentifierType": "EISSN"
+    },
+    {
+      "relationType": "Describes",
+      "relatedIdentifier": "10013/epic.10033",
+      "resourceTypeGeneral": "ConferenceProceeding",
+      "relatedIdentifierType": "Handle"
+    },
+    {
+      "relationType": "IsDescribedBy",
+      "relatedIdentifier": "IECUR0097",
+      "resourceTypeGeneral": "DataPaper",
+      "relatedIdentifierType": "IGSN"
+    },
+    {
+      "relationType": "HasMetadata",
+      "relatedIdentifier": "978-3-905673-82-1",
+      "resourceTypeGeneral": "Dataset",
+      "relatedIdentifierType": "ISBN"
+    },
+    {
+      "relationType": "IsMetadataFor",
+      "relatedIdentifier": "0077-5606",
+      "resourceTypeGeneral": "Dissertation",
+      "relatedIdentifierType": "ISSN"
+    },
+    {
+      "relationType": "HasVersion",
+      "relatedIdentifier": "0A9 2002 12B4A105 7",
+      "resourceTypeGeneral": "Event",
+      "relatedIdentifierType": "ISTC"
+    },
+    {
+      "relationType": "IsVersionOf",
+      "relatedIdentifier": "1188-1534",
+      "resourceTypeGeneral": "Image",
+      "relatedIdentifierType": "LISSN"
+    },
+    {
+      "relationType": "IsNewVersionOf",
+      "relatedIdentifier": "urn:lsid:ubio.org:namebank:11815",
+      "resourceTypeGeneral": "InteractiveResource",
+      "relatedIdentifierType": "LSID"
+    },
+    {
+      "relationType": "IsPreviousVersionOf",
+      "relatedIdentifier": "12082125",
+      "resourceTypeGeneral": "Journal",
+      "relatedIdentifierType": "PMID"
+    },
+    {
+      "relationType": "IsPartOf",
+      "relatedIdentifier": "http://purl.oclc.org/foo/bar",
+      "resourceTypeGeneral": "JournalArticle",
+      "relatedIdentifierType": "PURL"
+    },
+    {
+      "relationType": "HasPart",
+      "relatedIdentifier": "123456789999",
+      "resourceTypeGeneral": "Model",
+      "relatedIdentifierType": "UPC"
+    },
+    {
+      "relationType": "IsPublishedIn",
+      "relatedIdentifier": "http://www.heatflow.und.edu/index2.html",
+      "resourceTypeGeneral": "OutputManagementPlan",
+      "relatedIdentifierType": "URL"
+    },
+    {
+      "relationType": "IsReferencedBy",
+      "relatedIdentifier": "urn:nbn:de:101:1-201102033592",
+      "resourceTypeGeneral": "PeerReview",
+      "relatedIdentifierType": "URN"
+    },
+    {
+      "relationType": "References",
+      "relatedIdentifier": "https://w3id.org/games/spec/coil#Coil_Bomb_Die_Of_Age",
+      "resourceTypeGeneral": "PhysicalObject",
+      "relatedIdentifierType": "w3id"
+    },
+    {
+      "relationType": "IsDocumentedBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Preprint",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "Documents",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Report",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsCompiledBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Service",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "Compiles",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Software",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsVariantFormOf",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Sound",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsOriginalFormOf",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Standard",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsIdenticalTo",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Text",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsReviewedBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Workflow",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "Reviews",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsDerivedFrom",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsSourceOf",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsRequiredBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "Requires",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "Obsoletes",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsObsoletedBy",
+      "relatedIdentifier": "10.1016/j.epsl.2011.11.037",
+      "resourceTypeGeneral": "Other",
+      "relatedIdentifierType": "DOI"
+    }
+  ],
+  "relatedItems": [],
+  "sizes": [
+    "1 MB",
+    "90 pages"
+  ],
+  "formats": [
+    "application/xml",
+    "text/plain"
+  ],
+  "version": "1",
+  "rightsList": [
+    {
+      "rights": "Creative Commons Public Domain Dedication and Certification",
+      "rightsUri": "https://creativecommons.org/licenses/publicdomain/",
+      "schemeUri": "https://spdx.org/licenses/",
+      "rightsIdentifier": "cc-pddc",
+      "rightsIdentifierScheme": "SPDX"
+    }
+  ],
+  "descriptions": [
+    {
+      "lang": "en",
+      "description": "Example Abstract",
+      "descriptionType": "Abstract"
+    },
+    {
+      "lang": "en",
+      "description": "Example Methods",
+      "descriptionType": "Methods"
+    },
+    {
+      "lang": "en",
+      "description": "Example SeriesInformation",
+      "descriptionType": "SeriesInformation"
+    },
+    {
+      "lang": "en",
+      "description": "Example TableOfContents",
+      "descriptionType": "TableOfContents"
+    },
+    {
+      "lang": "en",
+      "description": "Example TechnicalInfo",
+      "descriptionType": "TechnicalInfo"
+    },
+    {
+      "lang": "en",
+      "description": "Example Other",
+      "descriptionType": "Other"
+    }
+  ],
+  "geoLocations": [
+    {
+      "geoLocationBox": {
+        "eastBoundLongitude": -123.02,
+        "northBoundLatitude": 49.315,
+        "southBoundLatitude": 49.195,
+        "westBoundLongitude": -123.27
+      },
+      "geoLocationPlace": "Vancouver, British Columbia, Canada",
+      "geoLocationPoint": {
+        "pointLatitude": 49.2827,
+        "pointLongitude": -123.1207
+      }
+    }
+  ],
+  "fundingReferences": [
+    {
+      "awardUri": "https://example.com/example-award-uri",
+      "awardTitle": "Example AwardTitle",
+      "funderName": "Example Funder",
+      "awardNumber": "12345",
+      "funderIdentifier": "https://doi.org/10.13039/501100000780",
+      "funderIdentifierType": "Crossref Funder ID"
+    }
+  ],
+  "url": "https://example.com/",
+  "schemaVersion": "http://datacite.org/schema/kernel-4"
+}

--- a/tests/data/datacite-v4.5-full-example.xml
+++ b/tests/data/datacite-v4.5-full-example.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/B09Z-4K37</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">ExampleFamilyName, ExampleGivenName</creatorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+    </creator>
+    <creator>
+      <creatorName nameType="Organizational">ExampleOrganization</creatorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</nameIdentifier>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Example Title</title>
+    <title titleType="Subtitle" xml:lang="en">Example Subtitle</title>
+    <title titleType="TranslatedTitle" xml:lang="fr">Example TranslatedTitle</title>
+    <title titleType="AlternativeTitle" xml:lang="en">Example AlternativeTitle</title>
+  </titles>
+  <publisher xml:lang="en" publisherIdentifier="https://ror.org/04z8jg394" publisherIdentifierScheme="ROR" schemeURI="https://ror.org/">Example Publisher</publisher>
+  <publicationYear>2022</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset">Example ResourceType</resourceType>
+  <subjects>
+    <subject subjectScheme="Fields of Science and Technology (FOS)" schemeURI="http://www.oecd.org/science/inno" valueURI="http://www.oecd.org/science/inno/38235147.pdf">FOS: Computer and information sciences</subject>
+    <subject subjectScheme="Australian and New Zealand Standard Research Classification (ANZSRC), 2020" schemeURI="https://www.abs.gov.au/statistics/classifications/australian-and-new-zealand-standard-research-classification-anzsrc" valueURI="https://www.abs.gov.au/statistics/classifications/australian-and-new-zealand-standard-research-classification-anzsrc/2020">Digital curation and preservation</subject>
+    <subject>Example Subject</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="ContactPerson">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="DataCollector">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="DataCurator">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="DataManager">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Distributor">
+      <contributorName nameType="Organizational">ExampleOrganization</contributorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Editor">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">ExampleOrganization</contributorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Producer">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="ProjectLeader">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="ProjectManager">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="ProjectMember">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="RegistrationAgency">
+      <contributorName nameType="Organizational">DataCite</contributorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/04wxnsj81</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="RegistrationAuthority">
+      <contributorName nameType="Organizational">International DOI Foundation</contributorName>
+      <nameIdentifier nameIdentifierScheme="" schemeURI=""/>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="RelatedPerson">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Researcher">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="ResearchGroup">
+      <contributorName>ExampleContributor</contributorName>
+      <affiliation affiliationIdentifier="https://ror.org/03yrm5c26" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">ExampleOrganization</affiliation>
+    </contributor>
+    <contributor contributorType="RightsHolder">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Sponsor">
+      <contributorName>ExampleContributor</contributorName>
+      <affiliation affiliationIdentifier="https://ror.org/03yrm5c26" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</affiliation>
+    </contributor>
+    <contributor contributorType="Supervisor">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="WorkPackageLeader">
+      <contributorName nameType="Organizational">ExampleOrganization</contributorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</nameIdentifier>
+      <affiliation/>
+    </contributor>
+    <contributor contributorType="Other">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427/</nameIdentifier>
+      <affiliation/>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Accepted">2022-01-01</date>
+    <date dateType="Available">2022-01-01</date>
+    <date dateType="Copyrighted">2022-01-01</date>
+    <date dateType="Collected">2021-01-01/2021/12-31</date>
+    <date dateType="Created">2022-01-01</date>
+    <date dateType="Issued">2022-01-01</date>
+    <date dateType="Submitted">2022-01-01</date>
+    <date dateType="Updated">2022-01-01</date>
+    <date dateType="Valid">2022-01-01</date>
+    <date dateType="Withdrawn">2022-01-01</date>
+    <date dateType="Other" dateInformation="ExampleDateInformation">2022-01-01</date>
+  </dates>
+  <language>en</language>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="Local accession number">12345</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="ARK" relationType="IsCitedBy" resourceTypeGeneral="Audiovisual">ark:/13030/tqb3kh97gh8w</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="arXiv" relationType="Cites" resourceTypeGeneral="Book">arXiv:0706.0001</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="bibcode" relationType="IsSupplementTo" resourceTypeGeneral="BookChapter">2018AGUFM.A24K..07S</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Collection">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="EAN13" relationType="IsContinuedBy" resourceTypeGeneral="ComputationalNotebook">9783468111242</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="EISSN" relationType="Continues" resourceTypeGeneral="ConferencePaper">1562-6865</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="Handle" relationType="Describes" resourceTypeGeneral="ConferenceProceeding">10013/epic.10033</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="IGSN" relationType="IsDescribedBy" resourceTypeGeneral="DataPaper">IECUR0097</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="ISBN" relationType="HasMetadata" resourceTypeGeneral="Dataset">978-3-905673-82-1</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="ISSN" relationType="IsMetadataFor" resourceTypeGeneral="Dissertation">0077-5606</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="ISTC" relationType="HasVersion" resourceTypeGeneral="Event">0A9 2002 12B4A105 7</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="LISSN" relationType="IsVersionOf" resourceTypeGeneral="Image">1188-1534</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="LSID" relationType="IsNewVersionOf" resourceTypeGeneral="InteractiveResource">urn:lsid:ubio.org:namebank:11815</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="PMID" relationType="IsPreviousVersionOf" resourceTypeGeneral="Journal">12082125</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="PURL" relationType="IsPartOf" resourceTypeGeneral="JournalArticle">http://purl.oclc.org/foo/bar</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="UPC" relationType="HasPart" resourceTypeGeneral="Model">123456789999</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsPublishedIn" resourceTypeGeneral="OutputManagementPlan">http://www.heatflow.und.edu/index2.html</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URN" relationType="IsReferencedBy" resourceTypeGeneral="PeerReview">urn:nbn:de:101:1-201102033592</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="w3id" relationType="References" resourceTypeGeneral="PhysicalObject">https://w3id.org/games/spec/coil#Coil_Bomb_Die_Of_Age</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsDocumentedBy" resourceTypeGeneral="Preprint">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Documents" resourceTypeGeneral="Report">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCompiledBy" resourceTypeGeneral="Service">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Compiles" resourceTypeGeneral="Software">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsVariantFormOf" resourceTypeGeneral="Sound">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsOriginalFormOf" resourceTypeGeneral="Standard">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsIdenticalTo" resourceTypeGeneral="Text">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsReviewedBy" resourceTypeGeneral="Workflow">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Reviews" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsDerivedFrom" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSourceOf" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsRequiredBy" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Requires" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Obsoletes" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsObsoletedBy" resourceTypeGeneral="Other">10.1016/j.epsl.2011.11.037</relatedIdentifier>
+  </relatedIdentifiers>
+  <sizes>
+    <size>1 MB</size>
+    <size>90 pages</size>
+  </sizes>
+  <formats>
+    <format>application/xml</format>
+    <format>text/plain</format>
+  </formats>
+  <version>1</version>
+  <rightsList>
+    <rights rightsURI="https://creativecommons.org/licenses/publicdomain/">Creative Commons Public Domain Dedication and Certification</rights>
+  </rightsList>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">Example Abstract</description>
+    <description xml:lang="en" descriptionType="Methods">Example Methods</description>
+    <description xml:lang="en" descriptionType="SeriesInformation">Example SeriesInformation</description>
+    <description xml:lang="en" descriptionType="TableOfContents">Example TableOfContents</description>
+    <description xml:lang="en" descriptionType="TechnicalInfo">Example TechnicalInfo</description>
+    <description xml:lang="en" descriptionType="Other">Example Other</description>
+  </descriptions>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPlace>Vancouver, British Columbia, Canada</geoLocationPlace>
+      <geoLocationPoint>
+        <pointLatitude>49.2827</pointLatitude>
+        <pointLongitude>-123.1207</pointLongitude>
+      </geoLocationPoint>
+      <geoLocationBox>
+        <westBoundLongitude>-123.27</westBoundLongitude>
+        <eastBoundLongitude>-123.02</eastBoundLongitude>
+        <southBoundLatitude>49.195</southBoundLatitude>
+        <northBoundLatitude>49.315</northBoundLatitude>
+      </geoLocationBox>
+    </geoLocation>
+  </geoLocations>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>Example Funder</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/501100000780</funderIdentifier>
+      <awardNumber awardURI="https://example.com/example-award-uri">12345</awardNumber>
+      <awardTitle>Example AwardTitle</awardTitle>
+    </fundingReference>
+  </fundingReferences>
+</resource>

--- a/tests/example/full.py
+++ b/tests/example/full.py
@@ -1,39 +1,34 @@
-from datacite import DataCiteMDSClient, schema42
+from datacite import DataCiteMDSClient, schema45
 
-# If you want to generate XML for earlier versions, you need to use either the
-# schema31, schema40 or schema41 instead.
+prefix = "10.1234"
 
 data = {
-    'identifiers': [{
-        'identifierType': 'DOI',
-        'identifier': '10.1234/foo.bar',
-    }],
-    'creators': [
-        {'name': 'Smith, John'},
+    "doi": f"{prefix}/test-doi",
+    "creators": [
+        {"name": "Smith, John"},
     ],
-    'titles': [
-        {'title': 'Minimal Test Case', }
+    "titles": [
+        {
+            "title": "Minimal Test Case",
+        }
     ],
-    'publisher': 'Invenio Software',
-    'publicationYear': '2015',
-    'types': {
-        'resourceType': 'Dataset',
-        'resourceTypeGeneral': 'Dataset'
-    },
-    'schemaVersion': 'http://datacite.org/schema/kernel-4',
+    "publisher": {"name": "Invenio Software"},
+    "publicationYear": "2015",
+    "types": {"resourceType": "Dataset", "resourceTypeGeneral": "Dataset"},
+    "schemaVersion": "http://datacite.org/schema/kernel-4",
 }
 
 # Validate dictionary
-assert schema42.validate(data)
+assert schema45.validate(data)
 
 # Generate DataCite XML from dictionary.
-doc = schema42.tostring(data)
+doc = schema45.tostring(data)
 
 # Initialize the MDS client.
 d = DataCiteMDSClient(
-    username='MYDC.MYACCOUNT',
-    password='mypassword',
-    prefix='10.1234',
+    username="DATACITE.ACCOUNT",
+    password="mypassword",
+    prefix=prefix,
     test_mode=True,
 )
 
@@ -41,24 +36,26 @@ d = DataCiteMDSClient(
 d.metadata_post(doc)
 
 # Mint new DOI
-d.doi_post('10.1234/test-doi', 'http://example.org/test-doi')
+d.doi_post(f"{prefix}/test-doi", "http://example.org/test-doi")
 
 # Get DOI location
-location = d.doi_get("10.1234/test-doi")
+location = d.doi_get(f"{prefix}/test-doi")
 
 # Set alternate URL for content type (available through content negotiation)
 d.media_post(
-    "10.1234/test-doi",
-    {"application/json": "http://example.org/test-doi/json/",
-     "application/xml": "http://example.org/test-doi/xml/"}
+    f"{prefix}/test-doi",
+    {
+        "application/json": "http://example.org/test-doi/json/",
+        "application/xml": "http://example.org/test-doi/xml/",
+    },
 )
 
 # Get alternate URLs
-mapping = d.media_get("10.1234/test-doi")
+mapping = d.media_get(f"{prefix}/test-doi")
 assert mapping["application/json"] == "http://example.org/test-doi/json/"
 
 # Get metadata for DOI
-doc = d.metadata_get("10.1234/test-doi")
+doc = d.metadata_get(f"{prefix}/test-doi")
 
 # Make DOI inactive
-d.metadata_delete("10.1234/test-doi")
+d.metadata_delete(f"{prefix}/test-doi")

--- a/tests/example/full_rest.py
+++ b/tests/example/full_rest.py
@@ -1,42 +1,51 @@
 import os
-from datacite import DataCiteRESTClient, schema42
-
-# If you want to generate XML for earlier versions, you need to use either the
-# schema31, schema40 or schema41 instead.
+from datacite import DataCiteRESTClient, schema45
 
 data = {
-    'identifiers': [{
-        'identifierType': 'DOI',
-        'identifier': '10.1234/foo.bar',
-    }],
-    'creators': [
-        {'name': 'Smith, John'},
+    "creators": [
+        {"name": "Smith, John"},
     ],
-    'titles': [
-        {'title': 'Minimal Test Case', }
+    "titles": [
+        {
+            "title": "Minimal Test Case",
+        }
     ],
-    'publisher': 'Invenio Software',
-    'publicationYear': '2015',
-    'types': {
-        'resourceType': 'Dataset',
-        'resourceTypeGeneral': 'Dataset'
-    },
-    'schemaVersion': 'http://datacite.org/schema/kernel-4',
+    "publisher": {"name": "Invenio Software"},
+    "publicationYear": "2015",
+    "types": {"resourceType": "Dataset", "resourceTypeGeneral": "Dataset"},
+    "schemaVersion": "http://datacite.org/schema/kernel-4",
 }
 
 # Validate dictionary
-assert schema42.validate(data)
+schema45.validator.validate(data)
 
 # Generate DataCite XML from dictionary.
-doc = schema42.tostring(data)
+doc = schema45.tostring(data)
+
+print(doc)
 
 # Initialize the REST client.
 d = DataCiteRESTClient(
-    username="MYDC.MYACCOUNT",
+    username="DATACITE.ACCOUNT",
     password="mypassword",
-    prefix="10.1234",
-    test_mode=True
+    prefix="10.12345",
+    test_mode=True,
 )
 
+# Mint a DOI
+doi = d.public_doi(data, "http://example.org/test-doi")
+print(doi)
+
 # Reserve a draft DOI
-doi = d.draft_doi()
+doi = d.draft_doi(data)
+print(doi)
+
+# Make the DOI public
+url = d.update_url(doi, url="http://example.org/test-doi2")
+d.show_doi(doi)
+
+# Get the DOI metadata
+doc = d.get_metadata(doi)
+
+# Hide the DOI
+d.hide_doi(doi)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -95,3 +95,13 @@ TEST_43_JSON_FILES = [
     "data/4.3/datacite-example-ancientdates-v4.json",
     "data/datacite-v4.3-full-example.json",
 ]
+
+TEST_45_JSON_FILES = [
+    "data/4.5/datacite-example-dataset-v4.json",
+    "data/4.5/datacite-example-instrument-v4.json",
+    "data/4.5/datacite-example-multilingual-v4.json",
+    "data/4.5/datacite-example-relateditem1-v4.json",
+    "data/4.5/datacite-example-relateditem2-v4.json",
+    "data/4.5/datacite-example-relateditem3-v4.json",
+    "data/datacite-v4.5-full-example.json",
+]

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -17,6 +17,7 @@ import responses
 from helpers import (
     RESTURL,
     TEST_43_JSON_FILES,
+    TEST_45_JSON_FILES,
     get_credentials,
     get_rest,
     load_json_path,
@@ -99,7 +100,7 @@ def test_rest_create_draft_mock():
 
 @pytest.mark.parametrize("example_json43", TEST_43_JSON_FILES)
 @pytest.mark.pw
-def test_rest_create_public(example_json43):
+def test_rest_create_public_43(example_json43):
     """Test creating DOIs with all example metadata"""
     example_metadata = load_json_path(example_json43)
     url = "https://github.com/inveniosoftware/datacite"
@@ -113,6 +114,32 @@ def test_rest_create_public(example_json43):
     metadata = {"publisher": "Invenio"}
     new_metadata = d.update_doi(doi, metadata)
     assert new_metadata["publisher"] == "Invenio"
+    url = "https://github.com/inveniosoftware"
+    new_metadata = d.update_doi(doi, url=url)
+    assert new_metadata["url"] == url
+
+
+@pytest.mark.parametrize("example_json45", TEST_45_JSON_FILES)
+@pytest.mark.pw
+def test_rest_create_public_45(example_json45):
+    """Test creating DOIs with all example metadata"""
+    example_metadata = load_json_path(example_json45)
+    # We need to remove the example doi, since we want DataCite to
+    # mint one with our test prefix
+    example_metadata.pop("doi")
+    example_metadata.pop("prefix")
+    example_metadata.pop("suffix")
+    url = "https://github.com/inveniosoftware/datacite"
+    username, password, prefix = get_credentials()
+    d = get_rest(
+        username=username, password=password, prefix=prefix, with_fake_url=False
+    )
+    doi = d.public_doi(example_metadata, url)
+    datacite_prefix = doi.split("/")[0]
+    assert datacite_prefix == prefix
+    metadata = {"subjects": [{"subject": "Invenio"}]}
+    new_metadata = d.update_doi(doi, metadata)
+    assert new_metadata["subjects"][0]["subject"] == "Invenio"
     url = "https://github.com/inveniosoftware"
     new_metadata = d.update_doi(doi, url=url)
     assert new_metadata["url"] == url

--- a/tests/test_schema45.py
+++ b/tests/test_schema45.py
@@ -1,0 +1,627 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DataCite.
+#
+# Copyright (C) 2016 CERN.
+# Copyright (C) 2019 Caltech.
+# Copyright (C) 2024 IBT Czech Academy of Sciences.
+#
+# DataCite is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Tests for format transformations."""
+
+import pytest
+from helpers import TEST_45_JSON_FILES, load_json_path, load_xml_path
+from lxml import etree
+
+from datacite.schema45 import dump_etree, tostring, validator
+
+
+def validate_json(minimal_json, extra_json):
+    """Validate specific property."""
+    data = {}
+    data.update(minimal_json)
+    data.update(extra_json)
+    validator.validate(data)
+
+
+@pytest.mark.parametrize("example_json45", TEST_45_JSON_FILES)
+def test_example_json_validates(example_json45):
+    """Test the example file validates against the JSON schema."""
+    example_json = load_json_path(example_json45)
+    validator.validate(example_json)
+
+
+FILE_PAIRS = [
+    (
+        "data/4.5/datacite-example-dataset-v4.xml",
+        "data/4.5/datacite-example-dataset-v4.json",
+    ),
+    (
+        "data/4.5/datacite-example-instrument-v4.xml",
+        "data/4.5/datacite-example-instrument-v4.json",
+    ),
+    (
+        "data/4.5/datacite-example-multilingual-v4.xml",
+        "data/4.5/datacite-example-multilingual-v4.json",
+    ),
+    (
+        "data/4.5/datacite-example-relateditem1-v4.xml",
+        "data/4.5/datacite-example-relateditem1-v4.json",
+    ),
+    (
+        "data/4.5/datacite-example-relateditem2-v4.xml",
+        "data/4.5/datacite-example-relateditem2-v4.json",
+    ),
+    (
+        "data/4.5/datacite-example-relateditem3-v4.xml",
+        "data/4.5/datacite-example-relateditem3-v4.json",
+    ),
+    ("data/datacite-v4.5-full-example.xml", "data/datacite-v4.5-full-example.json"),
+]
+
+
+@pytest.mark.parametrize("example_xml45, example_json45", FILE_PAIRS)
+def test_json_to_xml(example_xml45, example_json45, xsd45):
+    """Test that example XML converts to example JSON."""
+    example_xml = load_xml_path(example_xml45)
+    example_json = load_json_path(example_json45)
+    xsd45.assertValid(etree.XML(example_xml.encode("utf8")))
+    xsd45.assertValid(etree.XML(tostring(example_json).encode("utf8")))
+
+
+def test_json_eq_xml(example_xml_file45, example_json45, xsd45):
+    """Test that example XML converts to example JSON."""
+    xsd45.assertValid(etree.XML(tostring(example_json45).encode("utf8")))
+
+
+#
+# Field by field tests.
+#
+def test_identifier(minimal_json45):
+    """Test identifier."""
+    data = {"doi": "10.1234/foo.bar"}
+    validate_json(minimal_json45, data)
+    tree = dump_etree(data)
+    elem = tree.xpath("/resource/identifier")[0]
+    assert elem.text == "10.1234/foo.bar"
+    assert elem.get("identifierType") == "DOI"
+
+
+def test_creators(minimal_json45):
+    """Test creators."""
+    pytest.raises(TypeError, dump_etree, {"creators": {"invalid": "data"}})
+
+    tree = dump_etree({"creators": []})
+    assert len(tree.xpath("/resource/creators")) == 0
+
+    tree = dump_etree(
+        {
+            "creators": [
+                {
+                    "name": "Smith, John",
+                }
+            ]
+        }
+    )
+    assert len(tree.xpath("/resource/creators/creator")) == 1
+    assert len(tree.xpath("/resource/creators/creator/creatorName")) == 1
+    assert len(tree.xpath("/resource/creators/creator/nameIdentifier")) == 0
+    assert len(tree.xpath("/resource/creators/creator/affiliation")) == 0
+
+    data = {
+        "creators": [
+            {
+                "name": "Smith, John",
+                "familyName": "Smith",
+                "givenName": "John",
+                "affiliation": [
+                    {
+                        "name": "DataCite",
+                        "affiliationIdentifier": "https://ror.org/04wxnsj81",
+                        "affiliationIdentifierScheme": "ROR",
+                    },
+                    {
+                        "name": "DataCite2",
+                        "affiliationIdentifier": "https://ror.org/04wxnsj81",
+                        "affiliationIdentifierScheme": "ROR",
+                    },
+                ],
+                "nameIdentifiers": [
+                    {
+                        "nameIdentifier": "1234",
+                        "schemeUri": "http://orcid.org",
+                        "nameIdentifierScheme": "orcid",
+                    },
+                ],
+            }
+        ]
+    }
+    validate_json(minimal_json45, data)
+
+    tree = dump_etree(data)
+    assert len(tree.xpath("/resource/creators/creator/creatorName")) == 1
+    assert len(tree.xpath("/resource/creators/creator/familyName")) == 1
+    assert len(tree.xpath("/resource/creators/creator/givenName")) == 1
+    assert len(tree.xpath("/resource/creators/creator/nameIdentifier")) == 1
+    assert len(tree.xpath("/resource/creators/creator/affiliation")) == 2
+
+    elem = dump_etree(data).xpath("/resource/creators/creator/affiliation")[0]
+    assert elem.text == "DataCite"
+    assert elem.get("affiliationIdentifier") == "https://ror.org/04wxnsj81"
+
+    elem = dump_etree(data).xpath("/resource/creators/creator/affiliation")[1]
+    assert elem.text == "DataCite2"
+    assert elem.get("affiliationIdentifier") == "https://ror.org/04wxnsj81"
+
+
+def test_titles(minimal_json45):
+    """Test titles."""
+    pytest.raises(TypeError, dump_etree, {"titles": {"invalid": "data"}})
+
+    tree = dump_etree({"titles": []})
+    assert len(tree.xpath("/resource/titles")) == 0
+
+    tree = dump_etree({"titles": [{"title": "Test"}]})
+    assert len(tree.xpath("/resource/titles")) == 1
+    assert len(tree.xpath("/resource/titles/title")) == 1
+
+    data = {"titles": [{"title": "Test", "titleType": "Subtitle"}]}
+    validate_json(minimal_json45, data)
+
+    elem = dump_etree(data).xpath("/resource/titles/title")[0]
+    assert elem.text == "Test"
+    assert elem.get("titleType") == "Subtitle"
+
+    elem = dump_etree({"titles": [{"title": "Test", "lang": "en"}]}).xpath(
+        "/resource/titles/title"
+    )[0]
+    assert elem.get("{xml}lang") == "en"
+
+
+def test_publisher(minimal_json45):
+    """Test publisher."""
+    data = {"publisher": {"name": "test"}}
+    validate_json(minimal_json45, data)
+    tree = dump_etree(data)
+    assert tree.xpath("/resource/publisher")[0].text == "test"
+
+    tree = dump_etree({"publisher": ""})
+    assert len(tree.xpath("/resource/publisher")) == 0
+
+
+def test_publicationyear(minimal_json45):
+    """Test publication year."""
+    data = {"publicationYear": "2002"}
+    validate_json(minimal_json45, data)
+    tree = dump_etree(data)
+    assert tree.xpath("/resource/publicationYear")[0].text == "2002"
+
+    tree = dump_etree({"publicationYear": None})
+    assert len(tree.xpath("/resource/publicationYear")) == 0
+
+
+def test_subjects(minimal_json45):
+    """Test subjects."""
+    pytest.raises(TypeError, dump_etree, {"subjects": {"invalid": "data"}})
+
+    tree = dump_etree({"subjects": []})
+    assert len(tree.xpath("/resource/subjects")) == 0
+
+    tree = dump_etree({"subjects": [{"subject": "test"}]})
+    assert len(tree.xpath("/resource/subjects/subject")) == 1
+
+    data = {
+        "subjects": [
+            {
+                "subject": "test",
+                "subjectScheme": "dewey",
+                "schemeUri": "dewey-uri",
+                "valueUri": "https://cern.ch",
+            }
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/subjects/subject")[0]
+    assert elem.text == "test"
+    assert elem.get("subjectScheme") == "dewey"
+    assert elem.get("schemeURI") == "dewey-uri"
+    assert elem.get("valueURI") == "https://cern.ch"
+
+
+def test_contributors(minimal_json45):
+    """Test contributors."""
+    pytest.raises(TypeError, dump_etree, {"contributors": {"invalid": "data"}})
+
+    tree = dump_etree({"contributors": []})
+    assert len(tree.xpath("/resource/contributors")) == 0
+
+    tree = dump_etree(
+        {
+            "contributors": [
+                {
+                    "name": "CERN",
+                    "nameType": "Organisational",
+                    "contributorType": "HostingInstitution",
+                }
+            ]
+        }
+    )
+    assert len(tree.xpath("/resource/contributors/contributor")) == 1
+    assert len(tree.xpath("/resource/contributors/contributor/contributorName")) == 1
+    cntr1 = tree.xpath("/resource/contributors/contributor/contributorName")[0]
+    assert cntr1.attrib["nameType"] == "Organisational"
+    assert len(tree.xpath("/resource/contributors/contributor/nameIdentifier")) == 0
+    assert len(tree.xpath("/resource/contributors/contributor/affiliation")) == 0
+
+    data = {
+        "contributors": [
+            {
+                "name": "Smith, John",
+                "nameType": "Personal",
+                "familyName": "Smith",
+                "givenName": "John",
+                "contributorType": "ContactPerson",
+                "affiliation": [
+                    {
+                        "name": "DataCite",
+                        "affiliationIdentifier": "https://ror.org/04wxnsj81",
+                        "affiliationIdentifierScheme": "ROR",
+                    }
+                ],
+                "nameIdentifiers": [
+                    {
+                        "nameIdentifier": "1234",
+                        "schemeUri": "http://orcid.org",
+                        "nameIdentifierScheme": "orcid",
+                    },
+                ],
+            }
+        ]
+    }
+    validate_json(minimal_json45, data)
+
+    tree = dump_etree(data)
+    assert len(tree.xpath("/resource/contributors/contributor/contributorName")) == 1
+    cntr1 = tree.xpath("/resource/contributors/contributor/contributorName")[0]
+    assert cntr1.attrib["nameType"] == "Personal"
+    assert len(tree.xpath("/resource/contributors/contributor/familyName")) == 1
+    assert len(tree.xpath("/resource/contributors/contributor/givenName")) == 1
+    assert len(tree.xpath("/resource/contributors/contributor/nameIdentifier")) == 1
+    assert len(tree.xpath("/resource/contributors/contributor/affiliation")) == 1
+
+
+def test_dates(minimal_json45):
+    """Test dates."""
+    tree = dump_etree({"dates": []})
+    assert len(tree.xpath("/resource/dates")) == 0
+
+    pytest.raises(KeyError, dump_etree, {"dates": [{"date": "2011-01-01"}]})
+
+    data = {
+        "dates": [
+            {
+                "date": "2011-01-01",
+                "dateType": "Accepted",
+                "dateInformation": "Date of paper acceptance.",
+            }
+        ]
+    }
+    validate_json(minimal_json45, data)
+
+    elem = dump_etree(data).xpath("/resource/dates/date")[0]
+    assert elem.text == "2011-01-01"
+    assert elem.get("dateType") == "Accepted"
+    assert elem.get("dateInformation") == "Date of paper acceptance."
+
+
+def test_language(minimal_json45):
+    """Test language."""
+    data = {"language": "en"}
+    validate_json(minimal_json45, data)
+    tree = dump_etree(data)
+    assert tree.xpath("/resource/language")[0].text == "en"
+
+    tree = dump_etree({"language": ""})
+    assert len(tree.xpath("/resource/language")) == 0
+
+
+def test_resourcetype(minimal_json45):
+    """Test resource type."""
+    data = {
+        "types": {"resourceTypeGeneral": "Software", "resourceType": "Science Software"}
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/resourceType")[0]
+    assert elem.get("resourceTypeGeneral") == "Software"
+    assert elem.text == "Science Software"
+
+
+def test_relatedidentifiers(minimal_json45):
+    """Test related identifiers."""
+    tree = dump_etree({"relatedIdentifiers": []})
+    assert len(tree.xpath("/resource/relatedIdentifiers")) == 0
+
+    data = {
+        "relatedIdentifiers": [
+            {
+                "relatedIdentifier": "10.1234/foo",
+                "relatedIdentifierType": "DOI",
+                "relationType": "Cites",
+            },
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/relatedIdentifiers/relatedIdentifier")[0]
+    assert elem.get("relatedIdentifierType") == "DOI"
+    assert elem.get("relationType") == "Cites"
+    assert elem.text == "10.1234/foo"
+
+    data = {
+        "relatedIdentifiers": [
+            {
+                "relatedIdentifier": "10.1234/foo",
+                "relatedIdentifierType": "DOI",
+                "relationType": "HasMetadata",
+                "relatedMetadataScheme": "MARC21",
+                "schemeUri": "http://loc.gov",
+                "schemeType": "XSD",
+                "resourceTypeGeneral": "Software",
+            },
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/relatedIdentifiers/relatedIdentifier")[0]
+    assert elem.get("relatedMetadataScheme") == "MARC21"
+    assert elem.get("schemeURI") == "http://loc.gov"
+    assert elem.get("schemeType") == "XSD"
+    assert elem.get("resourceTypeGeneral") == "Software"
+
+
+def test_sizes(minimal_json45):
+    """Test sizes."""
+    tree = dump_etree({"sizes": []})
+    assert len(tree.xpath("/resource/sizes")) == 0
+
+    data = {"sizes": ["123"]}
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/sizes/size")[0]
+    assert elem.text == "123"
+
+
+def test_formats(minimal_json45):
+    """Test formats."""
+    tree = dump_etree({"formats": []})
+    assert len(tree.xpath("/resource/formats")) == 0
+
+    data = {"formats": ["abc"]}
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/formats/format")[0]
+    assert elem.text == "abc"
+
+
+def test_version(minimal_json45):
+    """Test version."""
+    tree = dump_etree({"version": ""})
+    assert len(tree.xpath("/resource/version")) == 0
+
+    data = {"version": "v4.5"}
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/version")[0]
+    assert elem.text == "v4.5"
+
+
+def test_rights(minimal_json45):
+    """Test rights."""
+    tree = dump_etree({"rightsList": []})
+    assert len(tree.xpath("/resource/rightsList")) == 0
+
+    data = {
+        "rightsList": [
+            {"rights": "CC", "rightsUri": "http://cc.org", "lang": "en"},
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/rightsList/rights")[0]
+    assert elem.get("rightsURI") == "http://cc.org"
+    assert elem.get("{xml}lang") == "en"
+    assert elem.text == "CC"
+
+
+def test_descriptions(minimal_json45):
+    """Test descriptions."""
+    tree = dump_etree({"descriptions": []})
+    assert len(tree.xpath("/resource/descriptions")) == 0
+
+    data = {
+        "descriptions": [
+            {
+                "description": "Test",
+                "descriptionType": "Abstract",
+            },
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/descriptions/description")[0]
+    assert elem.get("descriptionType") == "Abstract"
+    assert elem.text == "Test"
+
+
+def test_fundingreferences(minimal_json45):
+    """Test funding references."""
+    tree = dump_etree({"fundingReferences": []})
+    assert len(tree.xpath("/resource/fundingReferences")) == 0
+
+    data = {
+        "fundingReferences": [
+            {
+                "funderName": "funderName",
+                "funderIdentifier": "id",
+                "funderIdentifierType": "ISNI",
+                "awardNumber": "282625",
+                "awardUri": "https://cern.ch",
+                "awardTitle": "title",
+            },
+        ]
+    }
+    validate_json(minimal_json45, data)
+    elem = dump_etree(data).xpath("/resource/fundingReferences/fundingReference")[0]
+    name = elem.xpath("funderName")[0]
+    assert name.text == "funderName"
+    id = elem.xpath("funderIdentifier")[0]
+    assert id.text == "id"
+    assert id.get("funderIdentifierType") == "ISNI"
+    award = elem.xpath("awardNumber")[0]
+    assert award.text == "282625"
+    assert award.get("awardURI") == "https://cern.ch"
+    title = elem.xpath("awardTitle")[0]
+    assert title.text == "title"
+
+
+def test_geolocations(minimal_json45):
+    """Test geolocation."""
+    tree = dump_etree({"geoLocations": []})
+    assert len(tree.xpath("/resource/geoLocations")) == 0
+
+    data = {
+        "geoLocations": [
+            {
+                "geoLocationPoint": {"pointLongitude": 31.12, "pointLatitude": 67},
+                "geoLocationBox": {
+                    "westBoundLongitude": 31.12,
+                    "eastBoundLongitude": 67,
+                    "southBoundLatitude": 32,
+                    "northBoundLatitude": 68,
+                },
+                "geoLocationPlace": "Atlantic Ocean",
+                "geoLocationPolygon": [
+                    {
+                        "polygonPoint": {
+                            "pointLongitude": -71.032,
+                            "pointLatitude": 41.090,
+                        }
+                    },
+                    {
+                        "polygonPoint": {
+                            "pointLongitude": -68.211,
+                            "pointLatitude": 42.893,
+                        }
+                    },
+                    {
+                        "polygonPoint": {
+                            "pointLongitude": -72.032,
+                            "pointLatitude": 39.090,
+                        }
+                    },
+                    {
+                        "polygonPoint": {
+                            "pointLongitude": -71.032,
+                            "pointLatitude": 41.090,
+                        }
+                    },
+                    {
+                        "inPolygonPoint": {
+                            "pointLongitude": -52.032,
+                            "pointLatitude": 12.090,
+                        },
+                    },
+                ],
+            }
+        ]
+    }
+    validate_json(minimal_json45, data)
+
+    elem = dump_etree(data).xpath("/resource/geoLocations/geoLocation")[0]
+    pointlong = elem.xpath("geoLocationPoint/pointLongitude")[0]
+    pointlat = elem.xpath("geoLocationPoint/pointLatitude")[0]
+    assert pointlong.text == "31.12"
+    assert pointlat.text == "67"
+    boxwest = elem.xpath("geoLocationBox/westBoundLongitude")[0]
+    boxest = elem.xpath("geoLocationBox/eastBoundLongitude")[0]
+    boxsouth = elem.xpath("geoLocationBox/southBoundLatitude")[0]
+    boxnorth = elem.xpath("geoLocationBox/northBoundLatitude")[0]
+    assert boxwest.text == "31.12"
+    assert boxest.text == "67"
+    assert boxsouth.text == "32"
+    assert boxnorth.text == "68"
+    place = elem.xpath("geoLocationPlace")[0]
+    assert place.text == "Atlantic Ocean"
+    polygon = elem.xpath("geoLocationPolygon")[0]
+    points = polygon.xpath("polygonPoint")
+    p1long = points[0].xpath("pointLongitude")[0]
+    p1lat = points[0].xpath("pointLatitude")[0]
+    p2long = points[1].xpath("pointLongitude")[0]
+    p2lat = points[1].xpath("pointLatitude")[0]
+    p3long = points[2].xpath("pointLongitude")[0]
+    p3lat = points[2].xpath("pointLatitude")[0]
+    p4long = points[3].xpath("pointLongitude")[0]
+    p4lat = points[3].xpath("pointLatitude")[0]
+    assert p1long.text == "-71.032"
+    assert p1lat.text == "41.09"
+    assert p2long.text == "-68.211"
+    assert p2lat.text == "42.893"
+    assert p3long.text == "-72.032"
+    assert p3lat.text == "39.09"
+    assert p4long.text == "-71.032"
+    assert p4lat.text == "41.09"
+    inp = polygon.xpath("inPolygonPoint")[0]
+    inplat = inp.xpath("pointLatitude")[0]
+    inplong = inp.xpath("pointLongitude")[0]
+    assert inplat.text == "12.09"
+    assert inplong.text == "-52.032"
+
+
+#
+# Additional tests
+#
+def test_minimal_xsd(xsd45, minimal_json45):
+    """Test that example XML converts to example JSON."""
+    validator.validate(minimal_json45)
+    xsd45.assertValid(etree.XML(tostring(minimal_json45).encode("utf8")))
+
+
+def test_minimal_xml(xsd45):
+    """Test minimal xml."""
+    xml = """
+    <resource
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="http://datacite.org/schema/kernel-4"
+     xsi:schemaLocation="http://datacite.org/schema/kernel-4
+      http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+        <identifier identifierType="DOI">10.1234/foo.bar</identifier>
+        <creators>
+            <creator><creatorName>Nielsen, Lars Holm</creatorName></creator>
+        </creators>
+        <titles>
+            <title>Minimal Test Case</title>
+        </titles>
+        <publisher>Invenio Software</publisher>
+        <publicationYear>2016</publicationYear>
+        <resourceType resourceTypeGeneral="Software"></resourceType>
+    </resource>"""
+    xsd45.assertValid(etree.XML(xml))
+
+
+FIELD_NAMES = [
+    "dates",
+    "subjects",
+    "contributors",
+    "relatedIdentifiers",
+    "relatedItems",
+    "sizes",
+    "formats",
+    "rightsList",
+    "descriptions",
+    "geoLocations",
+    "fundingReferences",
+]
+
+
+@pytest.mark.parametrize("field_name", FIELD_NAMES)
+def test_empty_arrays(xsd45, minimal_json45, field_name):
+    """Test proper behavior with empty lists for certain fields."""
+    minimal_json45[field_name] = []
+    validator.validate(minimal_json45)
+    xsd45.assertValid(etree.XML(tostring(minimal_json45).encode("utf8")))


### PR DESCRIPTION
This PR adds DataCite 4.5 support. I'll leave this PR open for comments until at least 2024-07-11.

This is a major set of improvements, primarily contributed by @edager. @mfenner helped with some initial jsonschema work and reviews. This will close https://github.com/inveniosoftware/datacite/issues/81 https://github.com/inveniosoftware/datacite/issues/86 https://github.com/inveniosoftware/datacite/issues/80 and https://github.com/inveniosoftware/datacite/issues/76

Changes in version 4.5 include 

- Switches to jsonschema 2019-09 and adds more complete validation to catch mistyped elements
- Switches publisher from a string to an object. This means you will need to change publisher to be structured like `"publisher": {"name": "Invenio Software"}` when you use version 4.5. This change is needed to support the addition of publisher identifiers.
- Removes the identifiers field and added doi, prefix, and suffix fields. These fields are clearer, and DataCite appears to be moving away from the combined identifiers field. doi and prefix are not a required fields since you may or may not have them depending on your workflow.
- Adds new relatedItem elements for publication metadata
- Switches geolocation point values to numbers. This is to enable validation and is consistent with GeoJson and InvenioRDM. It is different from the DataCite REST API which uses strings, and submitted numbers will be turned into strings by DataCite.
- Reorganizes geolocationPolygon to how DataCite is currently rendering this metadata
- Adds support for the new resourceTypeGeneral and relationType values
- General jsonschema organization improvements